### PR TITLE
ISSUE-34-4: Allow Screen context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ build/
 .gradle
 local.properties
 *.iml
+android/.project
+android/.settings/org.eclipse.buildship.core.prefs
+DemoApp/android/.settings/org.eclipse.buildship.core.prefs
+DemoApp/android/.project
 
 # BUCK
 buck-out/

--- a/android/src/main/java/com/snowplowanalytics/react/tracker/RNSnowplowTrackerModule.java
+++ b/android/src/main/java/com/snowplowanalytics/react/tracker/RNSnowplowTrackerModule.java
@@ -46,6 +46,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                 .base64(false)
                 .mobileContext(true)
                 .screenviewEvents(options.hasKey("autoScreenView") ? options.getBoolean("autoScreenView") : false)
+                .screenContext(options.hasKey("setScreenContext") ? options.getBoolean("setScreenContext") : false)
                 .build()
         );
     }

--- a/ios/RNSnowplowTracker.m
+++ b/ios/RNSnowplowTracker.m
@@ -35,6 +35,9 @@ RCT_EXPORT_METHOD(initialize
         [builder setAppId:appId];
         [builder setTrackerNamespace:namespace];
         [builder setAutotrackScreenViews:options[@"autoScreenView"]];
+        if (options[@"setScreenContext"] == @YES ) {
+            [builder setScreenContext:YES];
+        }else [builder setScreenContext:NO];
         [builder setSubject:subject];
     }];
 }


### PR DESCRIPTION
Allow configuring the scree context by passing following optional values via options object.
Available options:

 - `setScreenContext` (boolean), defaults to `false`