### PR TITLE
ISSUE-34-6: Allow Install and Exception Event config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ build/
 .gradle
 local.properties
 *.iml
+android/.project
+android/.settings/org.eclipse.buildship.core.prefs
+DemoApp/android/.settings/org.eclipse.buildship.core.prefs
+DemoApp/android/.project
 
 # BUCK
 buck-out/

--- a/android/src/main/java/com/snowplowanalytics/react/tracker/RNSnowplowTrackerModule.java
+++ b/android/src/main/java/com/snowplowanalytics/react/tracker/RNSnowplowTrackerModule.java
@@ -46,6 +46,8 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                 .base64(false)
                 .mobileContext(true)
                 .screenviewEvents(options.hasKey("autoScreenView") ? options.getBoolean("autoScreenView") : false)
+                .installTracking(options.hasKey("setInstallEvent") ? options.getBoolean("setInstallEvent") : false)
+                .applicationCrash( options.hasKey("setExceptionEvents") ? options.getBoolean("setExceptionEvents") : false)
                 .build()
         );
     }

--- a/ios/RNSnowplowTracker.m
+++ b/ios/RNSnowplowTracker.m
@@ -35,6 +35,13 @@ RCT_EXPORT_METHOD(initialize
         [builder setAppId:appId];
         [builder setTrackerNamespace:namespace];
         [builder setAutotrackScreenViews:options[@"autoScreenView"]];
+        if (options[@"setInstallEvent"] == @YES ) {
+            [builder setInstallEvent:YES];
+        }else [builder setInstallEvent:NO];
+        if (options[@"setExceptionEvents"] == @YES ) {
+            [builder setExceptionEvents:YES];
+        }else [builder setExceptionEvents:NO];
+        [builder setSubject:subject];
         [builder setSubject:subject];
     }];
 }


### PR DESCRIPTION
Allow configuring Install and Exception Events by passing following optional values via options object. The Install event is working on iOS, on Android it needs additional instrumentation inside React Native App. Exception tracking needs additional instrumentation inside React Native App.
Available options: 

- `setInstallEvent` (boolean), defaults to `false`
- `setExceptionEvents` (boolean), defaults to `false`