### PR TITLE
ISSUE-33: Add Ability to track Page Views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ build/
 .gradle
 local.properties
 *.iml
+android/.project
+android/.settings/org.eclipse.buildship.core.prefs
+DemoApp/android/.settings/org.eclipse.buildship.core.prefs
+DemoApp/android/.project
 
 # BUCK
 buck-out/

--- a/android/src/main/java/com/snowplowanalytics/react/tracker/RNSnowplowTrackerModule.java
+++ b/android/src/main/java/com/snowplowanalytics/react/tracker/RNSnowplowTrackerModule.java
@@ -16,6 +16,7 @@ import com.snowplowanalytics.snowplow.tracker.emitter.RequestSecurity;
 import com.snowplowanalytics.snowplow.tracker.events.SelfDescribing;
 import com.snowplowanalytics.snowplow.tracker.events.Structured;
 import com.snowplowanalytics.snowplow.tracker.events.ScreenView;
+import com.snowplowanalytics.snowplow.tracker.events.PageView;
 
 public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
 
@@ -43,7 +44,6 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
         this.emitter.waitForEventStore();
         this.tracker = Tracker.init(new Tracker
                 .TrackerBuilder(this.emitter, namespace, appId, this.reactContext)
-                .base64(false)
                 .mobileContext(true)
                 .screenviewEvents(options.hasKey("autoScreenView") ? options.getBoolean("autoScreenView") : false)
                 .build()
@@ -81,6 +81,15 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                 transitionType, contexts);
         if (trackerEvent != null) {
             tracker.track(trackerEvent);
+        }
+    }
+    
+    @ReactMethod
+    public void trackPageView(String pageUrl, String pageTitle, String referrer, ReadableArray contexts) {
+        PageView trackerEvent = EventUtil.getPageViewEvent(pageUrl, pageTitle, referrer, contexts);
+        if (trackerEvent != null) {
+            tracker.track(trackerEvent);
+
         }
     }
 }

--- a/android/src/main/java/com/snowplowanalytics/react/util/EventUtil.java
+++ b/android/src/main/java/com/snowplowanalytics/react/util/EventUtil.java
@@ -6,6 +6,7 @@ import com.snowplowanalytics.snowplow.tracker.events.SelfDescribing;
 import com.snowplowanalytics.snowplow.tracker.events.Structured;
 import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
 import com.snowplowanalytics.snowplow.tracker.events.ScreenView;
+import com.snowplowanalytics.snowplow.tracker.events.PageView;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -69,6 +70,15 @@ public class EventUtil {
                 .previousId(previousScreenId)
                 .previousType(previousScreenType)
                 .transitionType(transitionType);
+        List<SelfDescribingJson> nativeContexts = EventUtil.getContexts(contexts);
+        if (nativeContexts != null) {
+            eventBuilder.customContext(nativeContexts);
+        }
+        return eventBuilder.build();
+    }
+    
+    public static PageView getPageViewEvent(String pageUrl, String pageTitle, String referrer, ReadableArray contexts) {
+        PageView.Builder eventBuilder = PageView.builder().pageUrl(pageUrl).pageTitle(pageTitle).referrer(referrer);
         List<SelfDescribingJson> nativeContexts = EventUtil.getContexts(contexts);
         if (nativeContexts != null) {
             eventBuilder.customContext(nativeContexts);

--- a/ios/RNSnowplowTracker.m
+++ b/ios/RNSnowplowTracker.m
@@ -95,4 +95,20 @@ RCT_EXPORT_METHOD(trackScreenViewEvent
       [self.tracker trackScreenViewEvent:SVevent];
 }
 
+RCT_EXPORT_METHOD(trackPageView
+                  :(nonnull NSString *)pageUrl // required (non-empty string)
+                  :(NSString *)pageTitle
+                  :(NSString *)pageReferrer
+                  :(NSArray<SPSelfDescribingJson *> *)contexts) {
+    SPPageView * trackerEvent = [SPPageView build:^(id<SPPageViewBuilder> builder) {
+        [builder setPageUrl:pageUrl];
+        if (pageTitle != nil) [builder setPageTitle:pageTitle];
+        if (pageReferrer != nil) [builder setReferrer:pageReferrer];
+        if (contexts) {
+            [builder setContexts:[[NSMutableArray alloc] initWithArray:contexts]];
+        }
+    }];
+    [self.tracker trackPageViewEvent:trackerEvent];
+}
+
 @end


### PR DESCRIPTION
Add ability to track page views by using `Tracker.trackPageView(pageUrl, pageTitle, pageReferrer, contexts)` function, where:
- `pageUrl` (string) - required, captures page URL
- `pageTitle` (string) - optional, captures page Title
- `pageReferrer` (string) - optional, captures page Referrer
- `contexts` (array of objects) - optional, captures additional contexts