### PR TITLE
ISSUE-34-8:Allow setting of UserID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ build/
 .gradle
 local.properties
 *.iml
+android/.project
+android/.settings/org.eclipse.buildship.core.prefs
+DemoApp/android/.settings/org.eclipse.buildship.core.prefs
+DemoApp/android/.project
 
 # BUCK
 buck-out/

--- a/android/src/main/java/com/snowplowanalytics/react/tracker/RNSnowplowTrackerModule.java
+++ b/android/src/main/java/com/snowplowanalytics/react/tracker/RNSnowplowTrackerModule.java
@@ -41,10 +41,16 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                 .security(protocol.equalsIgnoreCase("https") ? RequestSecurity.HTTPS : RequestSecurity.HTTP)
                 .build();
         this.emitter.waitForEventStore();
+        com.snowplowanalytics.snowplow.tracker.Subject subject = new com.snowplowanalytics.snowplow.tracker.Subject.SubjectBuilder()
+                .build();
+        if (options.hasKey("userId") && options.getString("userId") != null && !options.getString("userId").isEmpty()) {
+            subject.setUserId(options.getString("userId"));
+        }
         this.tracker = Tracker.init(new Tracker
                 .TrackerBuilder(this.emitter, namespace, appId, this.reactContext)
                 .base64(false)
                 .mobileContext(true)
+                .subject(subject)
                 .screenviewEvents(options.hasKey("autoScreenView") ? options.getBoolean("autoScreenView") : false)
                 .build()
         );
@@ -82,5 +88,10 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
         if (trackerEvent != null) {
             tracker.track(trackerEvent);
         }
+    }
+    
+    @ReactMethod
+    public void setUserId(String userId, ReadableMap options) {
+        tracker.instance().getSubject().setUserId(userId);
     }
 }

--- a/android/src/main/java/com/snowplowanalytics/react/tracker/RNSnowplowTrackerModule.java
+++ b/android/src/main/java/com/snowplowanalytics/react/tracker/RNSnowplowTrackerModule.java
@@ -46,6 +46,36 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
         if (options.hasKey("userId") && options.getString("userId") != null && !options.getString("userId").isEmpty()) {
             subject.setUserId(options.getString("userId"));
         }
+        if (options.hasKey("screenWidth") && options.hasKey("screenHeight")) {
+            subject.setScreenResolution(options.getInt("screenWidth"), options.getInt("screenHeight"));
+        }
+        if (options.hasKey("colorDepth")) {
+            subject.setColorDepth(options.getInt("colorDepth"));
+        }
+        if (options.hasKey("timezone") && options.getString("timezone") != null
+                && !options.getString("timezone").isEmpty()) {
+            subject.setTimezone(options.getString("timezone"));
+        }
+        if (options.hasKey("language") && options.getString("language") != null
+                && !options.getString("language").isEmpty()) {
+            subject.setLanguage(options.getString("language"));
+        }
+        if (options.hasKey("ipAddress") && options.getString("ipAddress") != null
+                && !options.getString("ipAddress").isEmpty()) {
+            subject.setIpAddress(options.getString("ipAddress"));
+        }
+        if (options.hasKey("useragent") && options.getString("useragent") != null
+                && !options.getString("useragent").isEmpty()) {
+            subject.setUseragent(options.getString("useragent"));
+        }
+        if (options.hasKey("networkUserId") && options.getString("networkUserId") != null
+                && !options.getString("networkUserId").isEmpty()) {
+            subject.setNetworkUserId(options.getString("networkUserId"));
+        }
+        if (options.hasKey("domainUserId") && options.getString("domainUserId") != null
+                && !options.getString("domainUserId").isEmpty()) {
+            subject.setDomainUserId(options.getString("domainUserId"));
+        }
         this.tracker = Tracker.init(new Tracker
                 .TrackerBuilder(this.emitter, namespace, appId, this.reactContext)
                 .base64(false)
@@ -91,7 +121,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
     }
     
     @ReactMethod
-    public void setUserId(String userId, ReadableMap options) {
+    public void setUserId(String userId) {
         tracker.instance().getSubject().setUserId(userId);
     }
 }

--- a/ios/RNSnowplowTracker.m
+++ b/ios/RNSnowplowTracker.m
@@ -22,9 +22,14 @@ RCT_EXPORT_METHOD(initialize
                   :(nonnull NSString *)appId
                   :(NSDictionary *)options
                   //:(BOOL *)autoScreenView
+                  //:(STRING *)userId
                 ) {
     SPSubject *subject = [[SPSubject alloc] initWithPlatformContext:YES andGeoContext:NO];
 
+    if (options[@"userId"] != nil) {
+        [subject setUserId:options[@"userId"]];
+    }
+    
     SPEmitter *emitter = [SPEmitter build:^(id<SPEmitterBuilder> builder) {
         [builder setUrlEndpoint:endpoint];
         [builder setHttpMethod:([@"post" caseInsensitiveCompare:method] == NSOrderedSame) ? SPRequestPost : SPRequestGet];
@@ -93,6 +98,21 @@ RCT_EXPORT_METHOD(trackScreenViewEvent
         }
       }];
       [self.tracker trackScreenViewEvent:SVevent];
+}
+
+RCT_EXPORT_METHOD(setUserId
+                  :(nonnull NSString *)userId // required (non-empty string),
+                  :(NSDictionary *)options
+                ) {
+    BOOL setPlatformContext = NO;
+    BOOL setGeoLocationContext = NO;
+    if (options[@"setPlatformContext"] == @YES ) setPlatformContext = YES;
+    if (options[@"setGeoLocationContext"] == @YES ) setGeoLocationContext = YES;
+    SPSubject * subject = [[SPSubject alloc] initWithPlatformContext:setPlatformContext andGeoContext:setGeoLocationContext];
+    if (userId != nil) {
+        [subject setUserId:userId];
+        [self.tracker setSubject:subject];
+    }
 }
 
 @end

--- a/ios/RNSnowplowTracker.m
+++ b/ios/RNSnowplowTracker.m
@@ -28,8 +28,8 @@ RCT_EXPORT_METHOD(initialize
     if (options[@"userId"] != nil) {
         [subject setUserId:options[@"userId"]];
     }
-    if (options[@"screenWidth"] != nil && options[@"screenHeigh"] != nil) {
-        [subject setResolutionWithWidth:[options[@"screenWidth"] integerValue] andHeight:[options[@"screenHeigh"] integerValue]];
+    if (options[@"screenWidth"] != nil && options[@"screenHeight"] != nil) {
+        [subject setResolutionWithWidth:[options[@"screenWidth"] integerValue] andHeight:[options[@"screenHeight"] integerValue]];
     }
     if (options[@"colorDepth"] != nil) {
         [subject setColorDepth:[options[@"colorDepth"] integerValue]];

--- a/ios/RNSnowplowTracker.m
+++ b/ios/RNSnowplowTracker.m
@@ -25,11 +25,33 @@ RCT_EXPORT_METHOD(initialize
                   //:(STRING *)userId
                 ) {
     SPSubject *subject = [[SPSubject alloc] initWithPlatformContext:YES andGeoContext:NO];
-
     if (options[@"userId"] != nil) {
         [subject setUserId:options[@"userId"]];
     }
-    
+    if (options[@"screenWidth"] != nil && options[@"screenHeigh"] != nil) {
+        [subject setResolutionWithWidth:[options[@"screenWidth"] integerValue] andHeight:[options[@"screenHeigh"] integerValue]];
+    }
+    if (options[@"colorDepth"] != nil) {
+        [subject setColorDepth:[options[@"colorDepth"] integerValue]];
+    }
+    if (options[@"timezone"] != nil) {
+        [subject setTimezone:options[@"timezone"]];
+    }
+    if (options[@"language"] != nil) {
+        [subject setLanguage:options[@"language"]];
+    }
+    if (options[@"ipAddress"] != nil) {
+        [subject setIpAddress:options[@"ipAddress"]];
+    }
+    if (options[@"useragent"] != nil) {
+        [subject setUseragent:options[@"useragent"]];
+    }
+    if (options[@"networkUserId"] != nil) {
+        [subject setNetworkUserId:options[@"networkUserId"]];
+    }
+    if (options[@"domainUserId"] != nil) {
+        [subject setDomainUserId:options[@"domainUserId"]];
+    }
     SPEmitter *emitter = [SPEmitter build:^(id<SPEmitterBuilder> builder) {
         [builder setUrlEndpoint:endpoint];
         [builder setHttpMethod:([@"post" caseInsensitiveCompare:method] == NSOrderedSame) ? SPRequestPost : SPRequestGet];
@@ -101,18 +123,14 @@ RCT_EXPORT_METHOD(trackScreenViewEvent
 }
 
 RCT_EXPORT_METHOD(setUserId
-                  :(nonnull NSString *)userId // required (non-empty string),
-                  :(NSDictionary *)options
+                  :(nonnull NSString *)userId // required (non-empty string)
                 ) {
-    BOOL setPlatformContext = NO;
-    BOOL setGeoLocationContext = NO;
-    if (options[@"setPlatformContext"] == @YES ) setPlatformContext = YES;
-    if (options[@"setGeoLocationContext"] == @YES ) setGeoLocationContext = YES;
-    SPSubject * subject = [[SPSubject alloc] initWithPlatformContext:setPlatformContext andGeoContext:setGeoLocationContext];
+    SPSubject * s = self.tracker.subject;
     if (userId != nil) {
-        [subject setUserId:userId];
-        [self.tracker setSubject:subject];
+        [s setUserId:userId];
+        [self.tracker setSubject:s];
     }
 }
+
 
 @end


### PR DESCRIPTION
Allow setting userID by passing following optional values via options object during `Tracker.initialize` or by invoking `setUserId` function (with `userId` containing User ID as a string)
Options available for `Tracker.initialize`, all optional:
- `userId` (string)
- `screenWidth` (integer)
- `screenHeight` (integer)
- `colorDepth` (integer)
- `timezone` (string)
- `language` (string)
- `ipAddress` (string)
- `useragent` (string)
- `networkUserId` (string)
- `domainUserId` (string)