### PR TITLE
Cleanup iOS bindings

### DIFF
--- a/ios/RNSnowplowTracker.m
+++ b/ios/RNSnowplowTracker.m
@@ -35,7 +35,7 @@ RCT_EXPORT_METHOD(initialize
                 ) {
     BOOL setPlatformContext = NO;
     BOOL setGeoLocationContext = NO;
-    if (options[@"setPlatformContext"] == @YES ) setPlatformContext = YES;
+    if ([options[@"setPlatformContext"] boolValue]) setPlatformContext = YES;
     SPSubject *subject = [[SPSubject alloc] initWithPlatformContext:setPlatformContext andGeoContext:setGeoLocationContext];
 
     SPEmitter *emitter = [SPEmitter build:^(id<SPEmitterBuilder> builder) {
@@ -47,17 +47,17 @@ RCT_EXPORT_METHOD(initialize
         [builder setEmitter:emitter];
         [builder setAppId:appId];
         // setBase64Encoded
-        if (options[@"setBase64Encoded"] == @YES ) {
+        if ([options[@"setBase64Encoded"] boolValue]) {
             [builder setBase64Encoded:YES];
         }else [builder setBase64Encoded:NO];
         [builder setTrackerNamespace:namespace];
         [builder setAutotrackScreenViews:options[@"autoScreenView"]];
         // setApplicationContext
-        if (options[@"setApplicationContext"] == @YES ) {
+        if ([options[@"setApplicationContext"] boolValue]) {
             [builder setApplicationContext:YES];
         }else [builder setApplicationContext:NO];
         // setSessionContextui
-        if (options[@"setSessionContext"] == @YES ) {
+        if ([options[@"setSessionContext"] boolValue]) {
             [builder setSessionContext:YES];
             if (options[@"checkInterval"] != nil) {
                 [builder setCheckInterval:[options[@"checkInterval"] integerValue]];
@@ -70,15 +70,15 @@ RCT_EXPORT_METHOD(initialize
             }else [builder setBackgroundTimeout:300];
         }else [builder setSessionContext:NO];
         // setLifecycleEvents
-        if (options[@"setLifecycleEvents"] == @YES ) {
+        if ([options[@"setLifecycleEvents"] boolValue]) {
             [builder setLifecycleEvents:YES];
         }else [builder setLifecycleEvents:NO];
         // setScreenContext
-        if (options[@"setScreenContext"] == @YES ) {
+        if ([options[@"setScreenContext"] boolValue]) {
             [builder setScreenContext:YES];
         }else [builder setScreenContext:NO];
         //setInstallEvent
-        if (options[@"setInstallEvent"] == @YES ) {
+        if ([options[@"setInstallEvent"] boolValue]) {
             [builder setInstallEvent:YES];
         }else [builder setInstallEvent:NO];
         [builder setSubject:subject];

--- a/ios/RNSnowplowTracker.m
+++ b/ios/RNSnowplowTracker.m
@@ -87,34 +87,34 @@ RCT_EXPORT_METHOD(initialize
 
 RCT_EXPORT_METHOD(setSubjectData :(NSDictionary *)options) {
       if (options[@"userId"] != nil) {
-              [self.self.tracker.subject setUserId:options[@"userId"]];
+              [self.tracker.subject setUserId:options[@"userId"]];
       }
       if (options[@"screenWidth"] != nil && options[@"screenHeight"] != nil) {
-          [self.self.tracker.subject setResolutionWithWidth:[options[@"screenWidth"] integerValue] andHeight:[options[@"screenHeight"] integerValue]];
+          [self.tracker.subject setResolutionWithWidth:[options[@"screenWidth"] integerValue] andHeight:[options[@"screenHeight"] integerValue]];
       }
       if (options[@"viewportWidth"] != nil && options[@"viewportHeight"] != nil) {
-          [self.self.tracker.subject setViewPortWithWidth:[options[@"viewportWidth"] integerValue] andHeight:[options[@"viewportHeight"] integerValue]];
+          [self.tracker.subject setViewPortWithWidth:[options[@"viewportWidth"] integerValue] andHeight:[options[@"viewportHeight"] integerValue]];
       }
       if (options[@"colorDepth"] != nil) {
-          [self.self.tracker.subject setColorDepth:[options[@"colorDepth"] integerValue]];
+          [self.tracker.subject setColorDepth:[options[@"colorDepth"] integerValue]];
       }
       if (options[@"timezone"] != nil) {
-          [self.self.tracker.subject setTimezone:options[@"timezone"]];
+          [self.tracker.subject setTimezone:options[@"timezone"]];
       }
       if (options[@"language"] != nil) {
-          [self.self.tracker.subject setLanguage:options[@"language"]];
+          [self.tracker.subject setLanguage:options[@"language"]];
       }
       if (options[@"ipAddress"] != nil) {
-          [self.self.tracker.subject setIpAddress:options[@"ipAddress"]];
+          [self.tracker.subject setIpAddress:options[@"ipAddress"]];
       }
       if (options[@"useragent"] != nil) {
-          [self.self.tracker.subject setUseragent:options[@"useragent"]];
+          [self.tracker.subject setUseragent:options[@"useragent"]];
       }
       if (options[@"networkUserId"] != nil) {
-          [self.self.tracker.subject setNetworkUserId:options[@"networkUserId"]];
+          [self.tracker.subject setNetworkUserId:options[@"networkUserId"]];
       }
       if (options[@"domainUserId"] != nil) {
-          [self.self.tracker.subject setDomainUserId:options[@"domainUserId"]];
+          [self.tracker.subject setDomainUserId:options[@"domainUserId"]];
       }
 }
 


### PR DESCRIPTION
Just a couple of small fixes to the iOS bindings:

1. There were some double calls to `self.self`, this can simply be replaced by `self`
2. There is an unsafe comparison (though it's fine in practice) that causes a compilation warning

<img width="616" alt="Screenshot 2020-05-07 at 10 54 38" src="https://user-images.githubusercontent.com/17656/81282398-05ab0200-9053-11ea-9c44-e0787c6653b8.png">

Technically this is comparing 2 pointers. It happens to work because the runtime does some magic to make sure that `@YES` is effectively a singleton instance. For correctness, it's best to compare the unboxed primitive boolean values directly.