### PR TITLE
Fix Xcode 12 compatibility

### DIFF
--- a/ios/RNSnowplowTracker.podspec
+++ b/ios/RNSnowplowTracker.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
 
-  s.dependency "React"
+  s.dependency "React-Core"
   s.dependency "SnowplowTracker", "~> 1.6.2"
   #s.dependency "others"
 


### PR DESCRIPTION
Latest Xcode 12 fails to build without a module to depend on React-Core directly hence this change is necessary for all native modules on iOS. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116.