### PR TITLE
Fix assembleAndroidTest builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,11 @@ android {
     compileSdkVersion 28
     buildToolsVersion "28.0.3"
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 28

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,7 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+ext.safeExtGet = this.&safeExtGet
 
 buildscript {
     repositories {
@@ -13,8 +17,8 @@ buildscript {
 apply plugin: "com.android.library"
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion safeExtGet('compileSdkVersion', 29)
+    buildToolsVersion safeExtGet('buildToolsVersion', '29.0.3')
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -22,8 +26,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion safeExtGet('minSdkVersion', 21)
+        targetSdkVersion safeExtGet('targetSdkVersion', 29)
         versionCode 1
         versionName "1.0"
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,6 @@
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
-ext.safeExtGet = this.&safeExtGet
 
 buildscript {
     repositories {


### PR DESCRIPTION
Fixes 2 issues when building and running instrumented tests (e.g. Detox) for a React Native project on Android, the following build errors were occurring:

## Issue 1:

```
* What went wrong:
Execution failed for task ':snowplow_react-native-tracker:mergeExtDexDebugAndroidTest'.
> Could not resolve all files for configuration ':snowplow_react-native-tracker:debugAndroidTestRuntimeClasspath'.
   > Failed to transform snowplow-android-tracker-1.5.0.aar (com.snowplowanalytics:snowplow-android-tracker:1.5.0) to match attributes {artifactType=android-dex, dexing-enable-desugaring=false, dexing-is-debuggable=true, dexing-min-sdk=16, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}.
      > Execution failed for DexingNoClasspathTransform: /Users/hudl/.gradle/caches/transforms-2/files-2.1/176f667f9cc26469654c4d804d4a3604/jetified-snowplow-android-tracker-1.5.0-runtime.jar.
         > Error while dexing.
           The dependency contains Java 8 bytecode. Please enable desugaring by adding the following to build.gradle
           android {
               compileOptions {
                   sourceCompatibility 1.8
                   targetCompatibility 1.8
               }
           }
           See https://developer.android.com/studio/write/java8-support.html for details. Alternatively, increase the minSdkVersion to 26 or above.
```

If an Android library uses Java 8 language features then it must declare compileOptions in its build.gradle.

> ...each module that uses Java 8 language features (either in its source code or through dependencies), update the module's build.gradle file, as shown below:

https://developer.android.com/studio/write/java8-support#supported_features

Similar fix here https://github.com/mockingbot/react-native-zip-archive/pull/236

## Issue 2:

In React Native 0.64 the min and target SDK versions have [changed](https://raw.githubusercontent.com/react-native-community/rn-diff-purge/release/0.64.0/RnDiffApp/android/build.gradle), however the SnowPlow RN library has hardcoded values for `compileSdkVersion`, `buildToolsVersion`, `minSdkVersion` and `targetSdkVersion`. So because React Native projects now target a higher minSdk then the following build errors are occurring.

```
> Task :snowplow_react-native-tracker:processDebugAndroidTestManifest FAILED
[androidx.vectordrawable:vectordrawable-animated:1.0.0] /Users/brent.kelly/.gradle/caches/transforms-2/files-2.1/e77c36db9a23f07ea6584b196a8c8323/vectordrawable-animated-1.0.0/AndroidManifest.xml Warning:
        Package name 'androidx.vectordrawable' used in: androidx.vectordrawable:vectordrawable-animated:1.0.0, androidx.vectordrawable:vectordrawable:1.0.1.
/Users/brent.kelly/dev/some-project/node_modules/@snowplow/react-native-tracker/android/build/intermediates/tmp/manifest/androidTest/debug/manifestMerger6791747903388050667.xml:5:5-74 Error:
        uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [com.facebook.react:react-native:0.64.0] /Users/brent.kelly/.gradle/caches/transforms-2/files-2.1/b6f7edcb35fd97b099ddfe438d86d13c/jetified-react-native-0.64.0/AndroidManifest.xml as the library might be using APIs not available in 16
        Suggestion: use a compatible library with a minSdk of at most 16,
                or increase this project's minSdk version to at least 21,
                or use tools:overrideLibrary="com.facebook.react" to force usage (may lead to runtime failures)
```

So to address these issues I added `compileOptions` to the `build.gradle` and updated `compileSdkVersion`, `buildToolsVersion`, `minSdkVersion` and `targetSdkVersion` to be controlled by the Android project that pulls in this library (as well as defaulting to the latest recommended versions from upstream React Native core). Allowing these values to be configured at the project level is quite common for React Native libraries e.g. https://github.com/react-native-async-storage/async-storage/blob/master/android/build.gradle#L79