### PR TITLE
Fix check for byteLimitGet when reading emitter configuration (close #138)

### DIFF
--- a/android/src/main/java/com/snowplowanalytics/react/util/ConfigUtil.java
+++ b/android/src/main/java/com/snowplowanalytics/react/util/ConfigUtil.java
@@ -193,7 +193,7 @@ public class ConfigUtil {
             int byteLimitPost = (int) emitterConfig.getDouble("byteLimitPost");
             emitterConfiguration.byteLimitPost(byteLimitPost);
         }
-        if (emitterConfig.hasKey("byteLimitPost")) {
+        if (emitterConfig.hasKey("byteLimitGet")) {
             int byteLimitGet = (int) emitterConfig.getDouble("byteLimitGet");
             emitterConfiguration.byteLimitGet(byteLimitGet);
         }


### PR DESCRIPTION
This is a small change in reading the emitter configuration in Java where a wrong attribute was read.