### PR TITLE
Add anonymous tracking features (close #168)

### DIFF
--- a/DemoApp/App.js
+++ b/DemoApp/App.js
@@ -116,6 +116,23 @@ const App = () => {
     },
   );
 
+  const anonymousTracker = createTracker(
+    'sp_anon',
+    {
+      endpoint: 'placeholder',
+    },
+    {
+      trackerConfig: {
+        screenViewAutotracking: false, // for tests predictability
+        installAutotracking: false,
+        userAnonymisation: true,
+      },
+      emitterConfig: {
+        serverAnonymisation: true,
+      },
+    },
+  );
+
   const onPressTrackScreenViewEvent = () => {
     tracker.trackScreenViewEvent({name: 'onlyRequired'});
     tracker.trackScreenViewEvent({
@@ -298,6 +315,14 @@ const App = () => {
     });
   };
 
+  const onPressTestAnonymousTracker = () => {
+    anonymousTracker.trackScreenViewEvent({name: 'fromAnonymousTracker'});
+    anonymousTracker.trackStructuredEvent({
+      category: 'AnonymousTracker',
+      action: 'trackAnonymous',
+    });
+  };
+
   const onPressPlayGC = async () => {
     try {
       await tracker.removeGlobalContexts('testTag');
@@ -413,6 +438,14 @@ const App = () => {
               title="Track events with second tracker"
               color="#841584"
               accessibilityLabel="testSecTracker"
+            />
+          </Section>
+          <Section title="Anonymous tracker">
+            <Button
+              onPress={onPressTestAnonymousTracker}
+              title="Track events with anonymous tracking"
+              color="#841584"
+              accessibilityLabel="testAnonymousTracker"
             />
           </Section>
           <Section title="Warnings">

--- a/DemoApp/tests/e2e/emitEvents.e2e.detox.js
+++ b/DemoApp/tests/e2e/emitEvents.e2e.detox.js
@@ -29,7 +29,7 @@ describe('Example', () => {
     await waitFor(element(by.label('testScreenView')))
       .toBeVisible()
       .whileElement(by.id('scrollView'))
-      .scroll(100, 'down');
+      .scroll(120, 'down');
 
     await element(by.label('testScreenView')).tap();
   });
@@ -38,7 +38,7 @@ describe('Example', () => {
     await waitFor(element(by.label('testSelfDesc')))
       .toBeVisible()
       .whileElement(by.id('scrollView'))
-      .scroll(100, 'down');
+      .scroll(120, 'down');
 
     await element(by.label('testSelfDesc')).tap();
   });
@@ -47,7 +47,7 @@ describe('Example', () => {
     await waitFor(element(by.label('testStruct')))
       .toBeVisible()
       .whileElement(by.id('scrollView'))
-      .scroll(100, 'down');
+      .scroll(120, 'down');
 
     await element(by.label('testStruct')).tap();
   });
@@ -56,7 +56,7 @@ describe('Example', () => {
     await waitFor(element(by.label('testPageView')))
       .toBeVisible()
       .whileElement(by.id('scrollView'))
-      .scroll(100, 'down');
+      .scroll(120, 'down');
 
     await element(by.label('testPageView')).tap();
   });
@@ -65,7 +65,7 @@ describe('Example', () => {
     await waitFor(element(by.label('testDeepLinkReceived')))
       .toBeVisible()
       .whileElement(by.id('scrollView'))
-      .scroll(100, 'down');
+      .scroll(120, 'down');
 
     await element(by.label('testDeepLinkReceived')).tap();
   });
@@ -74,7 +74,7 @@ describe('Example', () => {
     await waitFor(element(by.label('testMessageNotification')))
       .toBeVisible()
       .whileElement(by.id('scrollView'))
-      .scroll(100, 'down');
+      .scroll(120, 'down');
 
     await element(by.label('testMessageNotification')).tap();
   });
@@ -83,16 +83,25 @@ describe('Example', () => {
     await waitFor(element(by.label('testSecTracker')))
       .toBeVisible()
       .whileElement(by.id('scrollView'))
-      .scroll(100, 'down');
+      .scroll(120, 'down');
 
     await element(by.label('testSecTracker')).tap();
+  });
+
+  it('should tap Anonymous tracker Button', async () => {
+    await waitFor(element(by.label('testAnonymousTracker')))
+      .toBeVisible()
+      .whileElement(by.id('scrollView'))
+      .scroll(120, 'down');
+
+    await element(by.label('testAnonymousTracker')).tap();
   });
 
   it('should tap Subject Button', async () => {
     await waitFor(element(by.label('testSetSubject')))
       .toBeVisible()
       .whileElement(by.id('scrollView'))
-      .scroll(100, 'down');
+      .scroll(120, 'down');
 
     await element(by.label('testSetSubject')).tap();
   });

--- a/DemoApp/tests/e2e/testEvents.micro.test.js
+++ b/DemoApp/tests/e2e/testEvents.micro.test.js
@@ -19,11 +19,11 @@ test('no bad events', async () => {
 });
 
 test('number of screen_view events', async () => {
-  await commands.eventsWithSchema(schemas.screenView, 8);
+  await commands.eventsWithSchema(schemas.screenView, 9);
 });
 
 test('number of structured events', async () => {
-  await commands.eventsWithEventType('struct', 5);
+  await commands.eventsWithEventType('struct', 6);
 });
 
 test('number of page_view events', async () => {
@@ -269,6 +269,30 @@ test('second tracker events', async () => {
         {schema: schemas.mobileScreenContext},
         {schema: schemas.clientSessionContext},
       ],
+    },
+    2,
+  );
+});
+
+test('anonymous tracker events', async () => {
+  await commands.eventsWithProperties(
+    {
+      parameters: {
+        name_tracker: 'sp_anon',
+        network_userid: '00000000-0000-0000-0000-000000000000',
+      },
+      event: {
+        contexts: {
+          data: [
+            {
+              schema: schemas.clientSessionContext,
+              data: {
+                userId: '00000000-0000-0000-0000-000000000000',
+              },
+            },
+          ],
+        },
+      },
     },
     2,
   );

--- a/android/src/main/java/com/snowplowanalytics/react/util/ConfigUtil.java
+++ b/android/src/main/java/com/snowplowanalytics/react/util/ConfigUtil.java
@@ -161,6 +161,9 @@ public class ConfigUtil {
         if (trackerConfig.hasKey("deepLinkContext")) {
             trackerConfiguration.deepLinkContext(trackerConfig.getBoolean("deepLinkContext"));
         }
+        if (trackerConfig.hasKey("userAnonymisation")) {
+            trackerConfiguration.userAnonymisation(trackerConfig.getBoolean("userAnonymisation"));
+        }
 
         return trackerConfiguration;
     }
@@ -199,6 +202,9 @@ public class ConfigUtil {
         if (emitterConfig.hasKey("byteLimitGet")) {
             int byteLimitGet = (int) emitterConfig.getDouble("byteLimitGet");
             emitterConfiguration.byteLimitGet(byteLimitGet);
+        }
+        if (emitterConfig.hasKey("serverAnonymisation")) {
+            emitterConfiguration.serverAnonymisation(emitterConfig.getBoolean("serverAnonymisation"));
         }
 
         return emitterConfiguration;

--- a/ios/Util/RNConfigUtils.m
+++ b/ios/Util/RNConfigUtils.m
@@ -70,6 +70,7 @@
     trackerConfiguration.installAutotracking = [trackerConfig rnsp_boolForKey:@"installAutotracking" defaultValue:YES];
     trackerConfiguration.exceptionAutotracking = [trackerConfig rnsp_boolForKey:@"exceptionAutotracking" defaultValue:YES];
     trackerConfiguration.diagnosticAutotracking = [trackerConfig rnsp_boolForKey:@"diagnosticAutotracking" defaultValue:NO];
+    trackerConfiguration.userAnonymisation = [trackerConfig rnsp_boolForKey:@"userAnonymisation" defaultValue:NO];
 
     return trackerConfiguration;
 }
@@ -98,6 +99,7 @@
     emitterConfiguration.threadPoolSize = [[emitterConfig rnsp_numberForKey:@"threadPoolSize" defaultValue:@15] integerValue];
     emitterConfiguration.byteLimitGet = [[emitterConfig rnsp_numberForKey:@"byteLimitGet" defaultValue:@40000] integerValue];
     emitterConfiguration.byteLimitPost = [[emitterConfig rnsp_numberForKey:@"byteLimitPost" defaultValue:@40000] integerValue];
+    emitterConfiguration.serverAnonymisation = [emitterConfig rnsp_boolForKey:@"serverAnonymisation" defaultValue:NO];
 
     return emitterConfiguration;
 }

--- a/src/configurations.ts
+++ b/src/configurations.ts
@@ -48,7 +48,8 @@ const trackerProps= [
   'lifecycleAutotracking',
   'installAutotracking',
   'exceptionAutotracking',
-  'diagnosticAutotracking'
+  'diagnosticAutotracking',
+  'userAnonymisation'
 ];
 const sessionProps = [
   'foregroundTimeout',
@@ -60,6 +61,7 @@ const emitterProps = [
   'threadPoolSize',
   'byteLimitPost',
   'byteLimitGet',
+  'serverAnonymisation',
 ];
 const subjectProps = [
   'userId',

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,6 +163,11 @@ export interface TrackerConfiguration {
    * @defaultValue false
    */
   diagnosticAutotracking?: boolean;
+  /**
+   * Whether to anonymise client-side user identifiers in session and platform context entities
+   * @defaultValue false
+   */
+  userAnonymisation?: boolean;
 }
 
 
@@ -215,6 +220,12 @@ export interface EmitterConfiguration {
    * @defaultValue 40000
    */
   byteLimitGet?: number;
+
+  /**
+   * Whether to anonymise server-side user identifiers including the `network_userid` and `user_ipaddress`
+   * @defaultValue false
+   */
+  serverAnonymisation?: boolean;
 }
 
 /**

--- a/tests/__tests__/configurations.test.ts
+++ b/tests/__tests__/configurations.test.ts
@@ -222,7 +222,8 @@ describe('test initValidate resolves', () => {
         lifecycleAutotracking: false,
         installAutotracking: true,
         exceptionAutotracking: true,
-        diagnosticAutotracking: false
+        diagnosticAutotracking: false,
+        userAnonymisation: false
       },
       sessionConfig: {
         foregroundTimeout: 30,
@@ -234,6 +235,7 @@ describe('test initValidate resolves', () => {
         threadPoolSize: 15,
         byteLimitPost: 40000,
         byteLimitGet: 40000,
+        serverAnonymisation: false
       }
     };
     await expect(c.initValidate(testConfig as any)).resolves.toBe(true);
@@ -308,7 +310,8 @@ describe('test isValidTrackerConf', () => {
       screenContext: true,
       screenViewAutotracking: true,
       sessionContext: true,
-      deepLinkContext: true
+      deepLinkContext: true,
+      userAnonymisation: false
     } as any;
     expect(c.isValidTrackerConf(testConf)).toBe(true);
   });


### PR DESCRIPTION
Exposes the API from the mobile trackers to enable anonymous tracking features (issue #168).

Anonymous tracking on mobile trackers is provided by two configurations:

- `TrackerConfiguration.userAnonymisation` anonymises user identifiers in the `client_session` and `mobile_context` context entities. The `userId` in `client_session` is replaced with a null UUID and IDFA attributes in the platform context are removed.
- `EmitterConfiguration.serverAnonymisation` anonymises server-assigned identifiers. In particular, these are the `network_userid` and `user_ipaddress`.

This PR exposes the configuration options from the mobile trackers.