### PR TITLE
Remove circular imports of demo app dendencies when running in demo apps (close #174)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 # Demo app
 #
 DemoApp/
+DemoAppTV/
 
 # Local testing workflow
 #

--- a/DemoApp/package.json
+++ b/DemoApp/package.json
@@ -24,7 +24,8 @@
     "e2e:android": "run-p --race start e2e:test:android",
     "e2e:ios": "run-p --race start e2e:test:ios",
     "e2e:android:micro": "run-s -c micro:run e2e:android micro:stop",
-    "e2e:ios:micro": "run-s -c micro:run e2e:ios micro:stop"
+    "e2e:ios:micro": "run-s -c micro:run e2e:ios micro:stop",
+    "postinstall": "rimraf node_modules/@snowplow/react-native-tracker/{.git,node_modules,DemoApp,DemoAppTV}"
   },
   "dependencies": {
     "@jest/create-cache-key-function": "^27.0.2",

--- a/DemoAppTV/package.json
+++ b/DemoAppTV/package.json
@@ -8,7 +8,8 @@
     "start": "react-native start",
     "test": "jest",
     "lint": "eslint .",
-    "pods": "cd ios && rimraf Pods && pod install"
+    "pods": "cd ios && rimraf Pods && pod install",
+    "postinstall": "rimraf node_modules/@snowplow/react-native-tracker/{.git,node_modules,DemoApp,DemoAppTV}"
   },
   "dependencies": {
     "react": "17.0.2",
@@ -23,7 +24,8 @@
     "eslint": "7.14.0",
     "jest": "^26.6.3",
     "metro-react-native-babel-preset": "^0.66.2",
-    "react-test-renderer": "17.0.2"
+    "react-test-renderer": "17.0.2",
+    "rimraf": "^3.0.2"
   },
   "jest": {
     "preset": "react-native"

--- a/DemoAppTV/yarn.lock
+++ b/DemoAppTV/yarn.lock
@@ -5530,7 +5530,7 @@ rimraf@^2.5.4:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==


### PR DESCRIPTION
Issue #174 

# Problem

Currently, when one runs yarn inside the DemoApp or DemoAppTV folders, the whole parent folder is copied to satisfy the tracker dependency. However, this also includes the demo app themselves. This can result in ever increasing depth of recursive dependencies inside the demo apps.

The npm run bootstrap script in the tracker package handles this problem since it removes the node_modules in the DemoApp before installing. However, it doesn't consider the DemoAppTV app and also doesn't help if one runs yarn inside the demo app folder directly.

# Change

This PR adds a postinstall script to the demo apps that removes the `node_modules` folders in the copied tracker library.

# Failing tests

The tests are failing because they use an outdated macOS version for building. However, the PR #173 contains passing tests including this change.