### PR TITLE
Add interface to subscribe for events tracked in Web views (close #169)

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Prepare DemoApp for Micro
       working-directory: DemoApp
-      run: perl -i -pe "s/^.*endpoint:\K.*/ \'http:\/\/10.0.2.2:9090\'\,/" App.js
+      run: perl -i -pe "s/^.*collectorEndpoint =\K.*/ \'http:\/\/10.0.2.2:9090\'\;/" App.js
 
     # -- Tracker --
     - name: Use npm cache

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Prepare DemoApp for Micro
       working-directory: DemoApp
-      run: perl -i -pe "s/^.*endpoint:\K.*/ \'http:\/\/0.0.0.0:9090\'\,/" App.js
+      run: perl -i -pe "s/^.*collectorEndpoint =\K.*/ \'http:\/\/0.0.0.0:9090\'\;/" App.js
 
     # -- Tracker --
     - name: Use npm cache

--- a/DemoApp/App.js
+++ b/DemoApp/App.js
@@ -16,15 +16,27 @@ import {
   useColorScheme,
   View,
   Button,
+  Dimensions,
 } from 'react-native';
+import {WebView} from 'react-native-webview';
 
 import {Colors, Header} from 'react-native/Libraries/NewAppScreen';
 
 import {
   createTracker,
   removeTracker,
-  // removeAllTrackers,
+  getWebViewCallback,
 } from '@snowplow/react-native-tracker';
+
+/**
+ * URI of the Snowplow collector (e.g., Micro, Mini, or BDP) to send events to
+ */
+const collectorEndpoint = 'http://0.0.0.0:9090';
+
+/**
+ * URI of a website to load in the webview component
+ */
+const webViewEndpoint = '';
 
 const Section = ({children, title}) => {
   const isDarkMode = useColorScheme() === 'dark';
@@ -62,7 +74,7 @@ const App = () => {
   const tracker = createTracker(
     'sp1',
     {
-      endpoint: 'placeholder',
+      endpoint: collectorEndpoint,
     },
     {
       trackerConfig: {
@@ -106,7 +118,7 @@ const App = () => {
   const secTracker = createTracker(
     'sp2',
     {
-      endpoint: 'placeholder',
+      endpoint: collectorEndpoint,
     },
     {
       trackerConfig: {
@@ -119,7 +131,7 @@ const App = () => {
   const anonymousTracker = createTracker(
     'sp_anon',
     {
-      endpoint: 'placeholder',
+      endpoint: collectorEndpoint,
     },
     {
       trackerConfig: {
@@ -489,6 +501,21 @@ const App = () => {
               accessibilityLabel="testRemove"
             />
           </Section>
+          <Section title="Web view">
+            {webViewEndpoint ? (
+              <WebView
+                onMessage={getWebViewCallback()}
+                source={{uri: webViewEndpoint}}
+                style={{
+                  height: 400,
+                  width:
+                    Dimensions.get('window').width -
+                    styles.sectionContainer.paddingHorizontal,
+                }}
+              />
+            ) : null}
+          </Section>
+          <Section title="Last section"></Section>
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/DemoApp/App.js
+++ b/DemoApp/App.js
@@ -31,7 +31,7 @@ import {
 /**
  * URI of the Snowplow collector (e.g., Micro, Mini, or BDP) to send events to
  */
-const collectorEndpoint = 'http://0.0.0.0:9090';
+const collectorEndpoint = 'placeholder';
 
 /**
  * URI of a website to load in the webview component
@@ -515,7 +515,6 @@ const App = () => {
               />
             ) : null}
           </Section>
-          <Section title="Last section"></Section>
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/DemoApp/__mocks__/WebView.js
+++ b/DemoApp/__mocks__/WebView.js
@@ -1,0 +1,3 @@
+export default function WebView() {
+  return null;
+}

--- a/DemoApp/bin/app-prep-endpoint.js
+++ b/DemoApp/bin/app-prep-endpoint.js
@@ -14,8 +14,8 @@ const appFile = path.join(__dirname, '..', 'App.js');
 
 const validArg = ['android', 'ios'];
 
-const androidReplaceCmd = `perl -i -pe "s/^.*endpoint:\\K.*/ \\'http:\\/\\/${androidHost}:${microPort}\\'\\,/" ${appFile}`;
-const iosReplaceCmd = `perl -i -pe "s/^.*endpoint:\\K.*/ \\'http:\\/\\/${iosHost}:${microPort}\\'\\,/" ${appFile}`;
+const androidReplaceCmd = `perl -i -pe "s/^.*collectorEndpoint =\\K.*/ \\'http:\\/\\/${androidHost}:${microPort}\\'\\;/" ${appFile}`;
+const iosReplaceCmd = `perl -i -pe "s/^.*collectorEndpoint =\\K.*/ \\'http:\\/\\/${iosHost}:${microPort}\\'\\;/" ${appFile}`;
 
 const args = process.argv.slice(2);
 if (args.length === 1 && validArg.includes(args[0])) {

--- a/DemoApp/ios/Podfile.lock
+++ b/DemoApp/ios/Podfile.lock
@@ -286,6 +286,8 @@ PODS:
   - React-jsinspector (0.69.5)
   - React-logger (0.69.5):
     - glog
+  - react-native-webview (11.23.1):
+    - React-Core
   - React-perflogger (0.69.5)
   - React-RCTActionSheet (0.69.5):
     - React-Core/RCTActionSheetHeaders (= 0.69.5)
@@ -405,6 +407,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
+  - react-native-webview (from `../node_modules/react-native-webview`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
@@ -479,6 +482,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
+  react-native-webview:
+    :path: "../node_modules/react-native-webview"
   React-perflogger:
     :path: "../node_modules/react-native/ReactCommon/reactperflogger"
   React-RCTActionSheet:
@@ -542,6 +547,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: e42f0b46de293a026c2fb20e524d4fe09f81f575
   React-jsinspector: e385fb7a1440ae3f3b2cd1a139ca5aadaab43c10
   React-logger: 15c734997c06fe9c9b88e528fb7757601e7a56df
+  react-native-webview: d33e2db8925d090871ffeb232dfa50cb3a727581
   React-perflogger: 367418425c5e4a9f0f80385ee1eaacd2a7348f8e
   React-RCTActionSheet: e4885e7136f98ded1137cd3daccc05eaed97d5a6
   React-RCTAnimation: 7c5a74f301c9b763343ba98a3dd776ed2676993f

--- a/DemoApp/package.json
+++ b/DemoApp/package.json
@@ -31,7 +31,8 @@
     "@jest/create-cache-key-function": "^29.0.3",
     "@snowplow/react-native-tracker": "file:..",
     "react": "18.1.0",
-    "react-native": "0.69.5"
+    "react-native": "0.69.5",
+    "react-native-webview": "11.23.1"
   },
   "devDependencies": {
     "@babel/core": "^7.19.1",
@@ -62,6 +63,9 @@
     "verbose": true,
     "transformIgnorePatterns": [
       "node_modules/(?!(@react-native|react-native|@snowplow/react-native-tracker|react-native-button)/)"
-    ]
+    ],
+    "moduleNameMapper": {
+      "react-native-webview": "<rootDir>/__mocks__/WebView.js"
+    }
   }
 }

--- a/DemoApp/yarn.lock
+++ b/DemoApp/yarn.lock
@@ -3074,15 +3074,15 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
+escape-string-regexp@2.0.0, escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-
-escape-string-regexp@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
-  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
@@ -3968,7 +3968,7 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
-invariant@^2.2.4:
+invariant@2.2.4, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -6118,6 +6118,14 @@ react-native-gradle-plugin@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.7.tgz#96602f909745239deab7b589443f14fce5da2056"
   integrity sha512-+4JpbIx42zGTONhBTIXSyfyHICHC29VTvhkkoUOJAh/XHPEixpuBduYgf6Y4y9wsN1ARlQhBBoptTvXvAFQf5g==
+
+react-native-webview@11.23.1:
+  version "11.23.1"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.23.1.tgz#6a4bf2620e491dd4fecf4e6dc079005117fae12c"
+  integrity sha512-bmqsdg4RYOUYD37R9XTrQALm7eD62KbLNPRfgvpLGd1SjaurvAjjsLrLN4mt6yOtKOMKeZvlcAl3x6De6cCQsA==
+  dependencies:
+    escape-string-regexp "2.0.0"
+    invariant "2.2.4"
 
 react-native@0.69.5:
   version "0.69.5"

--- a/android/src/main/java/com/snowplowanalytics/react/tracker/RNSnowplowTrackerModule.java
+++ b/android/src/main/java/com/snowplowanalytics/react/tracker/RNSnowplowTrackerModule.java
@@ -137,7 +137,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                               Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             promise.resolve(Snowplow.removeTracker(trackerController));
 
@@ -165,7 +165,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             ReadableMap argmap = details.getMap("eventData");
             ReadableArray contexts = details.getArray("contexts");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             SelfDescribingJson sdj = EventUtil.createSelfDescribingJson(argmap);
             SelfDescribing event = new SelfDescribing(sdj);
@@ -189,7 +189,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             ReadableMap argmap = details.getMap("eventData");
             ReadableArray contexts = details.getArray("contexts");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             Structured event = EventUtil.createStructuredEvent(argmap);
 
@@ -212,7 +212,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             ReadableMap argmap = details.getMap("eventData");
             ReadableArray contexts = details.getArray("contexts");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             ScreenView event = EventUtil.createScreenViewEvent(argmap);
 
@@ -235,7 +235,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             ReadableMap argmap = details.getMap("eventData");
             ReadableArray contexts = details.getArray("contexts");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             PageView event = EventUtil.createPageViewEvent(argmap);
 
@@ -258,7 +258,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             ReadableMap argmap = details.getMap("eventData");
             ReadableArray contexts = details.getArray("contexts");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             Timing event = EventUtil.createTimingEvent(argmap);
 
@@ -281,7 +281,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             ReadableMap argmap = details.getMap("eventData");
             ReadableArray contexts = details.getArray("contexts");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             ConsentGranted event = EventUtil.createConsentGrantedEvent(argmap);
 
@@ -304,7 +304,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             ReadableMap argmap = details.getMap("eventData");
             ReadableArray contexts = details.getArray("contexts");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             ConsentWithdrawn event = EventUtil.createConsentWithdrawnEvent(argmap);
 
@@ -327,7 +327,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             ReadableMap argmap = details.getMap("eventData");
             ReadableArray contexts = details.getArray("contexts");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             EcommerceTransaction event = EventUtil.createEcommerceTransactionEvent(argmap);
 
@@ -350,7 +350,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             ReadableMap argmap = details.getMap("eventData");
             ReadableArray contexts = details.getArray("contexts");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             DeepLinkReceived event = EventUtil.createDeepLinkReceivedEvent(argmap);
 
@@ -373,7 +373,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             ReadableMap argmap = details.getMap("eventData");
             ReadableArray contexts = details.getArray("contexts");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             MessageNotification event = EventUtil.createMessageNotificationEvent(argmap);
 
@@ -395,7 +395,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             String namespace = details.getString("tracker");
             String tag = details.getString("removeTag");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             trackerController.getGlobalContexts().remove(tag);
             promise.resolve(true);
@@ -422,7 +422,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             }
             GlobalContext gcStatic = new GlobalContext(staticContexts);
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             trackerController.getGlobalContexts().add(tag, gcStatic);
             promise.resolve(true);
@@ -437,7 +437,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                           Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             if (details.isNull("userId")) {
                 trackerController.getSubject().setUserId(null);
@@ -456,7 +456,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                                  Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             if (details.isNull("networkUserId")) {
                 trackerController.getSubject().setNetworkUserId(null);
@@ -475,7 +475,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                                 Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             if (details.isNull("domainUserId")) {
                 trackerController.getSubject().setDomainUserId(null);
@@ -494,7 +494,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                              Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             if (details.isNull("ipAddress")) {
                 trackerController.getSubject().setIpAddress(null);
@@ -513,7 +513,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                              Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             if (details.isNull("useragent")) {
                 trackerController.getSubject().setUseragent(null);
@@ -532,7 +532,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                             Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             if (details.isNull("timezone")) {
                 trackerController.getSubject().setTimezone(null);
@@ -551,7 +551,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                             Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             if (details.isNull("language")) {
                 trackerController.getSubject().setLanguage(null);
@@ -570,7 +570,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                                     Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             if (details.isNull("screenResolution")) {
                 trackerController.getSubject().setScreenResolution(null);
@@ -594,7 +594,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                                   Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             if (details.isNull("screenViewport")) {
                 trackerController.getSubject().setScreenViewPort(null);
@@ -618,7 +618,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                               Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             if (details.isNull("colorDepth")) {
                 trackerController.getSubject().setColorDepth(null);
@@ -637,7 +637,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                                  Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             String suid = trackerController.getSession().getUserId();
             promise.resolve(suid);
@@ -651,7 +651,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                              Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             String sid = trackerController.getSession().getSessionId();
             promise.resolve(sid);
@@ -665,7 +665,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                                 Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             int sidx = trackerController.getSession().getSessionIndex();
             promise.resolve(sidx);
@@ -679,7 +679,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                                   Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             boolean isInBg = trackerController.getSession().isInBackground();
             promise.resolve(isInBg);
@@ -693,7 +693,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                                    Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             int bgIdx = trackerController.getSession().getBackgroundIndex();
             promise.resolve(bgIdx);
@@ -707,13 +707,17 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                                    Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             int fgIdx = trackerController.getSession().getForegroundIndex();
             promise.resolve(fgIdx);
         } catch(Throwable t) {
             promise.reject("ERROR", t.getMessage());
         }
+    }
+
+    private TrackerController getTracker(String namespace) {
+        return namespace == null ? Snowplow.getDefaultTracker() : Snowplow.getTracker(namespace);
     }
 
 }

--- a/ios/RNSnowplowTracker.m
+++ b/ios/RNSnowplowTracker.m
@@ -123,7 +123,7 @@ RCT_EXPORT_METHOD(removeTracker: (NSDictionary *)details
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
     BOOL removed = [SPSnowplow removeTracker:trackerController];
     resolve(@(removed));
 }
@@ -138,7 +138,7 @@ RCT_EXPORT_METHOD(trackSelfDescribingEvent:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *argmap = [details objectForKey:@"eventData"];
@@ -162,7 +162,7 @@ RCT_EXPORT_METHOD(trackStructuredEvent:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *argmap = [details objectForKey:@"eventData"];
@@ -199,7 +199,7 @@ RCT_EXPORT_METHOD(trackScreenViewEvent:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *argmap = [details objectForKey:@"eventData"];
@@ -250,7 +250,7 @@ RCT_EXPORT_METHOD(trackPageViewEvent:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *argmap = [details objectForKey:@"eventData"];
@@ -282,7 +282,7 @@ RCT_EXPORT_METHOD(trackTimingEvent:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *argmap = [details objectForKey:@"eventData"];
@@ -313,7 +313,7 @@ RCT_EXPORT_METHOD(trackConsentGrantedEvent:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *argmap = [details objectForKey:@"eventData"];
@@ -349,7 +349,7 @@ RCT_EXPORT_METHOD(trackConsentWithdrawnEvent:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *argmap = [details objectForKey:@"eventData"];
@@ -386,7 +386,7 @@ RCT_EXPORT_METHOD(trackEcommerceTransactionEvent:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *argmap = [details objectForKey:@"eventData"];
@@ -439,7 +439,7 @@ RCT_EXPORT_METHOD(trackDeepLinkReceivedEvent:
             resolver:(RCTPromiseResolveBlock)resolve
             rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *argmap = [details objectForKey:@"eventData"];
@@ -467,7 +467,7 @@ RCT_EXPORT_METHOD(trackMessageNotificationEvent:
             resolver:(RCTPromiseResolveBlock)resolve
             rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *argmap = [details objectForKey:@"eventData"];
@@ -581,7 +581,7 @@ RCT_EXPORT_METHOD(removeGlobalContexts:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSString *tag = [details objectForKey:@"removeTag"];
@@ -598,7 +598,7 @@ RCT_EXPORT_METHOD(addGlobalContexts:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *gcArg = [details objectForKey:@"addGlobalContext"];
@@ -621,7 +621,7 @@ RCT_EXPORT_METHOD(setUserId:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSString *newUid = [details rnsp_stringForKey:@"userId" defaultValue:nil];
@@ -638,7 +638,7 @@ RCT_EXPORT_METHOD(setNetworkUserId:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSString *newNuid = [details rnsp_stringForKey:@"networkUserId" defaultValue:nil];
@@ -655,7 +655,7 @@ RCT_EXPORT_METHOD(setDomainUserId:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSString *newDuid = [details rnsp_stringForKey:@"domainUserId" defaultValue:nil];
@@ -672,7 +672,7 @@ RCT_EXPORT_METHOD(setIpAddress:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSString *newIp = [details rnsp_stringForKey:@"ipAddress" defaultValue:nil];
@@ -689,7 +689,7 @@ RCT_EXPORT_METHOD(setUseragent:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSString *newUagent = [details rnsp_stringForKey:@"useragent" defaultValue:nil];
@@ -706,7 +706,7 @@ RCT_EXPORT_METHOD(setTimezone:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSString *newTz = [details rnsp_stringForKey:@"timezone" defaultValue:nil];
@@ -723,7 +723,7 @@ RCT_EXPORT_METHOD(setLanguage:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSString *newLang = [details rnsp_stringForKey:@"language" defaultValue:nil];
@@ -740,7 +740,7 @@ RCT_EXPORT_METHOD(setScreenResolution:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSObject *newRes = [details objectForKey:@"screenResolution"];
@@ -764,7 +764,7 @@ RCT_EXPORT_METHOD(setScreenViewport:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSObject *newView = [details objectForKey:@"screenViewport"];
@@ -788,7 +788,7 @@ RCT_EXPORT_METHOD(setColorDepth:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSNumber *newColorD = [details rnsp_numberForKey:@"colorDepth" defaultValue:nil];
@@ -805,7 +805,7 @@ RCT_EXPORT_METHOD(getSessionUserId:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSString *suid = [trackerController.session userId];
@@ -821,7 +821,7 @@ RCT_EXPORT_METHOD(getSessionId:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSString *sid = [trackerController.session sessionId];
@@ -837,7 +837,7 @@ RCT_EXPORT_METHOD(getSessionIndex:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSInteger sidx = [trackerController.session sessionIndex];
@@ -853,7 +853,7 @@ RCT_EXPORT_METHOD(getIsInBackground:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         BOOL isInBg = [trackerController.session isInBackground];
@@ -869,7 +869,7 @@ RCT_EXPORT_METHOD(getBackgroundIndex:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSInteger bgIdx = [trackerController.session backgroundIndex];
@@ -885,7 +885,7 @@ RCT_EXPORT_METHOD(getForegroundIndex:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSInteger fgIdx = [trackerController.session foregroundIndex];
@@ -894,6 +894,10 @@ RCT_EXPORT_METHOD(getForegroundIndex:
         NSError* error = [NSError errorWithDomain:@"SnowplowTracker" code:200 userInfo:nil];
         reject(@"ERROR", @"tracker with given namespace not found", error);
     }
+}
+
+- (nullable id<SPTrackerController>)trackerByNamespace:(NSString *)namespace {
+    return [namespace isEqual:[NSNull null]] ? [SPSnowplow defaultTracker] : [SPSnowplow trackerByNamespace:namespace];
 }
 
 @end

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import type {
   TrackerControllerConfiguration,
   ReactNativeTracker
 } from './types';
+import { getWebViewCallback } from './webViewInterface';
 
 /**
  * Creates a React Native Tracker object
@@ -143,6 +144,7 @@ export {
   createTracker,
   removeTracker,
   removeAllTrackers,
+  getWebViewCallback,
 };
 
 export type {

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -51,7 +51,7 @@ import type {
  * @returns {Promise}
  */
 function trackSelfDescribingEvent(
-  namespace: string,
+  namespace: string | null,
   argmap: SelfDescribing,
   contexts: EventContext[] = []
 ): Promise<void> {
@@ -77,7 +77,7 @@ function trackSelfDescribingEvent(
  * @returns {Promise}
  */
 function trackScreenViewEvent(
-  namespace: string,
+  namespace: string | null,
   argmap: ScreenViewProps,
   contexts: EventContext[] = []
 ): Promise<void> {
@@ -102,7 +102,7 @@ function trackScreenViewEvent(
  * @returns {Promise}
  */
 function trackStructuredEvent(
-  namespace: string,
+  namespace: string | null,
   argmap: StructuredProps,
   contexts: EventContext[] = []
 ): Promise<void> {
@@ -127,7 +127,7 @@ function trackStructuredEvent(
  * @returns {Promise}
  */
 function trackPageViewEvent(
-  namespace: string,
+  namespace: string | null,
   argmap: PageViewProps,
   contexts: EventContext[] = []
 ): Promise<void> {

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -152,7 +152,7 @@ function trackPageViewEvent(
  * @returns {Promise}
  */
 function trackTimingEvent(
-  namespace: string,
+  namespace: string | null,
   argmap: TimingProps,
   contexts: EventContext[] = []
 ): Promise<void> {
@@ -177,7 +177,7 @@ function trackTimingEvent(
  * @returns {Promise}
  */
 function trackConsentGrantedEvent(
-  namespace: string,
+  namespace: string | null,
   argmap: ConsentGrantedProps,
   contexts: EventContext[] = []
 ): Promise<void> {
@@ -202,7 +202,7 @@ function trackConsentGrantedEvent(
  * @returns {Promise}
  */
 function trackConsentWithdrawnEvent(
-  namespace: string,
+  namespace: string | null,
   argmap: ConsentWithdrawnProps,
   contexts: EventContext[] = []
 ): Promise<void> {
@@ -227,7 +227,7 @@ function trackConsentWithdrawnEvent(
  * @returns {Promise}
  */
 function trackEcommerceTransactionEvent(
-  namespace: string,
+  namespace: string | null,
   argmap: EcommerceTransactionProps,
   contexts: EventContext[] = []
 ): Promise<void> {
@@ -252,7 +252,7 @@ function trackEcommerceTransactionEvent(
  * @returns {Promise}
  */
 function trackDeepLinkReceivedEvent(
-  namespace: string,
+  namespace: string | null,
   argmap: DeepLinkReceivedProps,
   contexts: EventContext[] = []
 ): Promise<void> {
@@ -277,7 +277,7 @@ function trackDeepLinkReceivedEvent(
  * @returns {Promise}
  */
 function trackMessageNotificationEvent(
-  namespace: string,
+  namespace: string | null,
   argmap: MessageNotificationProps,
   contexts: EventContext[] = []
 ): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -912,3 +912,26 @@ export type ReactNativeTracker = {
    */
   readonly getForegroundIndex: () => Promise<number | undefined>;
 };
+
+/**
+ * Internal event type for page views tracked using the WebView tracker.
+ */
+export interface WebViewPageViewEvent {
+  title?: string | null;
+  url?: string;
+  referrer?: string;
+}
+
+/**
+ * Internal type exchanged in messages received from the WebView tracker in Web views through the web view callback.
+ */
+export type WebViewMessage = {
+  command:
+    | 'trackSelfDescribingEvent'
+    | 'trackStructEvent'
+    | 'trackPageView'
+    | 'trackScreenView';
+  event: StructuredProps | SelfDescribing | ScreenViewProps | WebViewPageViewEvent;
+  context?: Array<SelfDescribing> | null;
+  trackers?: Array<string>;
+};

--- a/src/webViewInterface.ts
+++ b/src/webViewInterface.ts
@@ -3,25 +3,14 @@ import {
   trackScreenViewEvent,
   trackSelfDescribingEvent,
   trackStructuredEvent,
-} from './tracker';
-import type { ScreenViewProps, SelfDescribing, StructuredProps } from './types';
-
-interface FullPageViewEvent {
-  title?: string | null;
-  url?: string;
-  referrer?: string;
-}
-
-type WebViewMessage = {
-  command:
-    | 'trackSelfDescribingEvent'
-    | 'trackStructEvent'
-    | 'trackPageView'
-    | 'trackScreenView';
-  event: StructuredProps | SelfDescribing | ScreenViewProps | FullPageViewEvent;
-  context?: Array<SelfDescribing> | null;
-  trackers?: Array<string>;
-};
+} from "./tracker";
+import type {
+  ScreenViewProps,
+  SelfDescribing,
+  StructuredProps,
+  WebViewPageViewEvent,
+  WebViewMessage,
+} from "./types";
 
 function forEachTracker(
   trackers: Array<string> | undefined,
@@ -73,7 +62,7 @@ export function getWebViewCallback() {
 
     case 'trackPageView':
       forEachTracker(data.trackers, (namespace) => {
-        const event = data.event as FullPageViewEvent;
+        const event = data.event as WebViewPageViewEvent;
         trackPageViewEvent(namespace, {
           pageTitle: event.title ?? '',
           pageUrl: event.url ?? '',

--- a/src/webViewInterface.ts
+++ b/src/webViewInterface.ts
@@ -1,0 +1,100 @@
+import {
+  trackPageViewEvent,
+  trackScreenViewEvent,
+  trackSelfDescribingEvent,
+  trackStructuredEvent,
+} from './tracker';
+import type { ScreenViewProps, SelfDescribing, StructuredProps } from './types';
+
+interface FullPageViewEvent {
+  title?: string | null;
+  url?: string;
+  referrer?: string;
+}
+
+type WebViewMessage = {
+  command:
+    | 'trackSelfDescribingEvent'
+    | 'trackStructEvent'
+    | 'trackPageView'
+    | 'trackScreenView';
+  event: StructuredProps | SelfDescribing | ScreenViewProps | FullPageViewEvent;
+  context?: Array<SelfDescribing> | null;
+  trackers?: Array<string>;
+};
+
+function forEachTracker(
+  trackers: Array<string> | undefined,
+  iterator: (namespace: string | null) => void
+): void {
+  if (trackers) {
+    trackers.forEach(iterator);
+  } else {
+    iterator(null);
+  }
+}
+
+/**
+ * Enables tracking events from apps rendered in react-native-webview components.
+ * The apps need to use the Snowplow WebView tracker to track the events.
+ * 
+ * To subscribe for the events, set the `onMessage` attribute:
+ * <WebView onMessage={getWebViewCallback()} ... />
+ * 
+ * @returns Callback to subscribe for events from Web views tracked using the Snowplow WebView tracker.
+ */
+export function getWebViewCallback() {
+  return (message: { nativeEvent: { data: string } }): void => {
+    const data = JSON.parse(message.nativeEvent.data) as WebViewMessage;
+    switch (data.command) {
+    case 'trackSelfDescribingEvent':
+      forEachTracker(data.trackers, (namespace) => {
+        trackSelfDescribingEvent(
+          namespace,
+            data.event as SelfDescribing,
+            data.context || []
+        ).catch((error) => {
+          console.error(error);
+        });
+      });
+      break;
+
+    case 'trackStructEvent':
+      forEachTracker(data.trackers, (namespace) => {
+        trackStructuredEvent(
+          namespace,
+            data.event as StructuredProps,
+            data.context || []
+        ).catch((error) => {
+          console.error(error);
+        });
+      });
+      break;
+
+    case 'trackPageView':
+      forEachTracker(data.trackers, (namespace) => {
+        const event = data.event as FullPageViewEvent;
+        trackPageViewEvent(namespace, {
+          pageTitle: event.title ?? '',
+          pageUrl: event.url ?? '',
+          referrer: event.referrer,
+        }).catch((error) => {
+          console.error(error);
+        });
+      });
+      break;
+
+    case 'trackScreenView':
+      forEachTracker(data.trackers, (namespace) => {
+        trackScreenViewEvent(
+          namespace,
+            data.event as ScreenViewProps,
+            data.context || []
+        ).catch((error) => {
+          console.error(error);
+        });
+      });
+      break;
+    }
+  };
+}

--- a/src/webViewInterface.ts
+++ b/src/webViewInterface.ts
@@ -3,14 +3,14 @@ import {
   trackScreenViewEvent,
   trackSelfDescribingEvent,
   trackStructuredEvent,
-} from "./tracker";
+} from './tracker';
 import type {
   ScreenViewProps,
   SelfDescribing,
   StructuredProps,
   WebViewPageViewEvent,
   WebViewMessage,
-} from "./types";
+} from './types';
 
 function forEachTracker(
   trackers: Array<string> | undefined,


### PR DESCRIPTION
Issue #169 

Enables events to be tracked from Web views (implemented using the [react-native-webview](https://github.com/react-native-webview/react-native-webview) component) when the Web view app uses the [WebView tracker](https://github.com/snowplow-incubator/snowplow-webview-tracker).

The communication between Web view app and the React native app is through the `window.ReactNativeInterface` object. The WebView tracker sends messages with tracked events to the object. In the React Native app, one needs to subscribe to the messages by setting the `onMessage` callback in the Web view:

```js
<WebView
   onMessage={getWebViewCallback()} ... />
```

The `getWebViewCallback` function is provided the React native tracker and creates a callback that processes the messages from the WebView tracker and tracks the passed events.

I opened a [PR in the WebView tracker](https://github.com/snowplow-incubator/snowplow-webview-tracker/pull/7) to add support for the `ReactNativeInterface`

## Demo apps

I updated the React Native demo app to add a Web view at the bottom of the app. One needs to set the `webViewEndpoint` variable in the `App.js` file to  to the URL of the app to be shown in the Web view.

There is an exapmle web app in the WebView tracker that can be used to track a few events in [this PR](https://github.com/snowplow-incubator/snowplow-webview-tracker/pull/8).