### PR TITLE
Add option to add custom headers (close #165)

### DIFF
--- a/DemoApp/App.js
+++ b/DemoApp/App.js
@@ -75,6 +75,9 @@ const App = () => {
     'sp1',
     {
       endpoint: collectorEndpoint,
+      requestHeaders: {
+        test: 'works',
+      },
     },
     {
       trackerConfig: {

--- a/DemoApp/tests/e2e/helpers/microCommands.js
+++ b/DemoApp/tests/e2e/helpers/microCommands.js
@@ -99,6 +99,7 @@ function eventsWithEventType(eventType, n = 1) {
  *     values: {
  *         testProperty: true
  *     },
+ *     header: "the: header"
  *     contexts: [{
  *         schema: "iglu:com.acme/test_context/jsonschema/1-0-0",
  *         data: {
@@ -123,11 +124,30 @@ function eventsWithProperties(eventOptions, n = 1) {
   });
 }
 
+/**
+ * Asserts on the number of events having a given HTTP request header
+ *
+ * ```
+ * eventsWithHeader("Connection: keep-alive", 2);
+ * ```
+ *
+ * @param {string} header The request header to match
+ * @param {number} [n=1] The expected number of matching events
+ */
+function eventsWithHeader(header, n = 1) {
+  n = parseInt(n, 10);
+  return getMicroGood().then(arr => {
+    const res = Micro.matchByHeader(arr, header);
+    expect(res.length).toBe(n);
+  });
+}
+
 export {
   assertNoBadEvents,
   eventsWithSchema,
   eventsWithEventType,
   eventsWithProperties,
+  eventsWithHeader,
   resetMicro,
   sleep,
 };

--- a/DemoApp/tests/e2e/helpers/microHelpers.js
+++ b/DemoApp/tests/e2e/helpers/microHelpers.js
@@ -137,6 +137,21 @@ function matchByContexts(eventsArray, expectedContextsArray) {
 }
 
 /**
+ * Filters an array of Snowplow events based on the request headers
+ *
+ * ```
+ * matchByHeader(goodEventsArray, "Connection: keep-alive");
+ *
+ * ```
+ * @param {Array} eventsArray An array of Snowplow events
+ * @param {string} header The HTTP request header to match
+ * @returns {Array} An array with the matching events
+ */
+function matchByHeader(eventsArray, header) {
+  return eventsArray.filter(hasHeader(header));
+}
+
+/**
  * Filters an array of Snowplow events based on event's Properties
  *
  * ```
@@ -155,7 +170,8 @@ function matchByContexts(eventsArray, expectedContextsArray) {
  *                 parameters: {
  *                     user_id: "tester",
  *                     name_tracker: "myTrackerName"
- *                 }
+ *                 },
+ *                 header: 'the: header',
  *             });
  * ```
  *
@@ -188,6 +204,10 @@ function matchEvents(microEvents, eventProps) {
 
   if (eventProps.parameters) {
     res = matchByParams(res, eventProps.parameters);
+  }
+
+  if (eventProps.header) {
+    res = matchByHeader(res, eventProps.header);
   }
 
   return res;
@@ -252,6 +272,12 @@ function hasContexts(expCoArr) {
   };
 }
 
+function hasHeader(header) {
+  return function (ev) {
+    return ev.rawEvent.context.headers.includes(header);
+  };
+}
+
 function keyIncludedIn(obj) {
   return function (key) {
     return Object.keys(obj).includes(key);
@@ -312,6 +338,7 @@ export {
   matchByVals,
   matchByParams,
   matchByContexts,
+  matchByHeader,
   matchEvents,
   compare,
   request,

--- a/DemoApp/tests/e2e/testEvents.micro.test.js
+++ b/DemoApp/tests/e2e/testEvents.micro.test.js
@@ -210,6 +210,7 @@ test('common in all first tracker events', async () => {
         platform: 'iot',
         name_tracker: 'sp1',
       },
+      header: 'test: works',
       contexts: [
         {schema: schemas.mobileApplicationContext},
         {schema: schemas.mobileContext},

--- a/ios/RNSnowplowTracker.m
+++ b/ios/RNSnowplowTracker.m
@@ -67,20 +67,24 @@ RCT_EXPORT_METHOD(createTracker:
     if (customPostPath != nil) {
         networkConfiguration.customPostPath = customPostPath;
     }
+    NSObject *requestHeaders = [networkConfig objectForKey:@"requestHeaders"];
+    if (requestHeaders != nil && [requestHeaders isKindOfClass:NSDictionary.class]) {
+        networkConfiguration.requestHeaders = (NSDictionary *)requestHeaders;
+    }
 
     // Configurations
     NSMutableArray *controllers = [NSMutableArray array];
 
     // TrackerConfiguration
     NSObject *trackerArg = [argmap objectForKey:@"trackerConfig"];
-    if (trackerArg !=nil && [trackerArg isKindOfClass:NSDictionary.class]) {
+    if (trackerArg != nil && [trackerArg isKindOfClass:NSDictionary.class]) {
         SPTrackerConfiguration *trackerConfiguration = [RNConfigUtils mkTrackerConfig:(NSDictionary *)trackerArg];
         [controllers addObject:trackerConfiguration];
     }
 
     // SessionConfiguration
     NSObject *sessionArg = [argmap objectForKey:@"sessionConfig"];
-    if (sessionArg !=nil && [sessionArg isKindOfClass:NSDictionary.class]) {
+    if (sessionArg != nil && [sessionArg isKindOfClass:NSDictionary.class]) {
         SPSessionConfiguration *sessionConfiguration = [RNConfigUtils mkSessionConfig:(NSDictionary *)sessionArg];
         [controllers addObject:sessionConfiguration];
     }

--- a/ios/RNSnowplowTracker.xcodeproj/project.pbxproj
+++ b/ios/RNSnowplowTracker.xcodeproj/project.pbxproj
@@ -8,8 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		0562F54E146600A44BDEF45D /* libPods-RNSnowplowTracker.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E15379B78A468FF69B0BDCA /* libPods-RNSnowplowTracker.a */; };
-		75D5EB7C2293B157005C8629 /* RCTConvert+Snowplow.m in Sources */ = {isa = PBXBuildFile; fileRef = 75D5EB7B2293B157005C8629 /* RCTConvert+Snowplow.m */; };
-		75D5EB7E2293B206005C8629 /* RCTConvert+Snowplow.h in Headers */ = {isa = PBXBuildFile; fileRef = 75D5EB7A2293B157005C8629 /* RCTConvert+Snowplow.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		75D5EB7F2293B206005C8629 /* RNSnowplowTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = B3E7B5881CC2AC0600A0062D /* RNSnowplowTracker.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		B3E7B58A1CC2AC0600A0062D /* RNSnowplowTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RNSnowplowTracker.m */; };
 /* End PBXBuildFile section */
@@ -29,8 +27,6 @@
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libRNSnowplowTracker.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNSnowplowTracker.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		4D25182CF98251495D063E8A /* Pods-RNSnowplowTracker.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNSnowplowTracker.release.xcconfig"; path = "Target Support Files/Pods-RNSnowplowTracker/Pods-RNSnowplowTracker.release.xcconfig"; sourceTree = "<group>"; };
-		75D5EB7A2293B157005C8629 /* RCTConvert+Snowplow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+Snowplow.h"; sourceTree = "<group>"; };
-		75D5EB7B2293B157005C8629 /* RCTConvert+Snowplow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RCTConvert+Snowplow.m"; sourceTree = "<group>"; };
 		7D2A97B8BEC452B270B0AA54 /* Pods-RNSnowplowTracker.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNSnowplowTracker.debug.xcconfig"; path = "Target Support Files/Pods-RNSnowplowTracker/Pods-RNSnowplowTracker.debug.xcconfig"; sourceTree = "<group>"; };
 		8E15379B78A468FF69B0BDCA /* libPods-RNSnowplowTracker.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNSnowplowTracker.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3E7B5881CC2AC0600A0062D /* RNSnowplowTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNSnowplowTracker.h; sourceTree = "<group>"; };
@@ -68,8 +64,6 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
-				75D5EB7A2293B157005C8629 /* RCTConvert+Snowplow.h */,
-				75D5EB7B2293B157005C8629 /* RCTConvert+Snowplow.m */,
 				B3E7B5881CC2AC0600A0062D /* RNSnowplowTracker.h */,
 				B3E7B5891CC2AC0600A0062D /* RNSnowplowTracker.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
@@ -94,7 +88,6 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				75D5EB7E2293B206005C8629 /* RCTConvert+Snowplow.h in Headers */,
 				75D5EB7F2293B206005C8629 /* RNSnowplowTracker.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -183,7 +176,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				75D5EB7C2293B157005C8629 /* RCTConvert+Snowplow.m in Sources */,
 				B3E7B58A1CC2AC0600A0062D /* RNSnowplowTracker.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/configurations.ts
+++ b/src/configurations.ts
@@ -36,6 +36,7 @@ const networkProps = [
   'endpoint',
   'method',
   'customPostPath',
+  'requestHeaders',
 ];
 const trackerProps= [
   'appId',

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,7 +89,12 @@ export interface NetworkConfiguration {
    * 
    * @defaultValue `com.snowplowanalytics.snowplow/tp2`.
    */
-   customPostPath?: string;
+  customPostPath?: string;
+
+  /**
+   * Custom headers for HTTP requests to the Collector.
+   */
+  requestHeaders?: [string: string];
 }
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,7 +94,7 @@ export interface NetworkConfiguration {
   /**
    * Custom headers for HTTP requests to the Collector.
    */
-  requestHeaders?: [name: string]
+  requestHeaders?: Record<string, string>;
 }
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,7 +94,7 @@ export interface NetworkConfiguration {
   /**
    * Custom headers for HTTP requests to the Collector.
    */
-  requestHeaders?: [string: string];
+  requestHeaders?: [name: string]
 }
 
 

--- a/tests/__tests__/configurations.test.ts
+++ b/tests/__tests__/configurations.test.ts
@@ -149,7 +149,7 @@ describe('test initValidate resolves', () => {
   test('test valid networkConfig', async () => {
     const testConfig = {
       namespace: 'sp1',
-      networkConfig: {endpoint: 'test', method: 'get', customPostPath: 'custom/path'}
+      networkConfig: {endpoint: 'test', method: 'get', customPostPath: 'custom/path', requestHeaders: {the: 'header'}}
     };
     await expect(c.initValidate(testConfig as any)).resolves.toBe(true);
   });


### PR DESCRIPTION
Issue #165 

Enables adding custom HTTP request headers to the collector requests using the `NetworkConfiguration.requestHeaders` option. The configuration is set by passing a dictionary of the headers, similar to the iOS tracker:

```js
networkConfig.requestHeaders = {
  "sp": "anonymous"
};
```

On iOS, the implementation is straightforward as it already provides the same configuration option in `NetworkConfiguration`.

However, the Android tracker doesn't expose an option to set custom headers in configuration. I had to do it by setting a custom HTTP client (`OkHttpClient`) which intercepts requests and adds the headers to them. We might change this in case we expose a configuration option for setting headers in the Android tracker.