### PR TITLE
Enable setting custom path for POST requests (close #178)

### DIFF
--- a/android/src/main/java/com/snowplowanalytics/react/tracker/RNSnowplowTrackerModule.java
+++ b/android/src/main/java/com/snowplowanalytics/react/tracker/RNSnowplowTrackerModule.java
@@ -73,6 +73,10 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             } else {
                 networkConfiguration = new NetworkConfiguration(networkConfig.getString("endpoint"));
             }
+            if (networkConfig.hasKey("customPostPath") && !networkConfig.isNull("customPostPath")) {
+                String customPostPath = networkConfig.getString("customPostPath");
+                networkConfiguration.customPostPath = customPostPath;
+            }
 
             // Configurations
             List<Configuration> controllers = new ArrayList<Configuration>();

--- a/ios/RNSnowplowTracker.m
+++ b/ios/RNSnowplowTracker.m
@@ -63,6 +63,10 @@ RCT_EXPORT_METHOD(createTracker:
     NSString *method = [networkConfig rnsp_stringForKey:@"method" defaultValue:nil];
     SPHttpMethod httpMethod = [@"get" isEqualToString:method] ? SPHttpMethodGet : SPHttpMethodPost;
     SPNetworkConfiguration *networkConfiguration = [[SPNetworkConfiguration alloc] initWithEndpoint:networkConfig[@"endpoint"] method:httpMethod];
+    NSString *customPostPath = [networkConfig rnsp_stringForKey:@"customPostPath" defaultValue:nil];
+    if (customPostPath != nil) {
+        networkConfiguration.customPostPath = customPostPath;
+    }
 
     // Configurations
     NSMutableArray *controllers = [NSMutableArray array];

--- a/src/configurations.ts
+++ b/src/configurations.ts
@@ -32,7 +32,11 @@ import type {
 /**
  * Configuration properties
  */
-const networkProps = ['endpoint', 'method'];
+const networkProps = [
+  'endpoint',
+  'method',
+  'customPostPath',
+];
 const trackerProps= [
   'appId',
   'devicePlatform',

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,7 +87,7 @@ export interface NetworkConfiguration {
    * A custom path which will be added to the endpoint URL to specify the
    * complete URL of the collector when paired with the POST method.
    * 
-   * The default is `com.snowplowanalytics.snowplow/tp2`.
+   * @defaultValue `com.snowplowanalytics.snowplow/tp2`.
    */
    customPostPath?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,8 @@ export interface NetworkConfiguration {
   /**
    * A custom path which will be added to the endpoint URL to specify the
    * complete URL of the collector when paired with the POST method.
+   * 
+   * The default is `com.snowplowanalytics.snowplow/tp2`.
    */
    customPostPath?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,12 @@ export interface NetworkConfiguration {
    * @defaultValue 'post'
    */
   method?: HttpMethod;
+
+  /**
+   * A custom path which will be added to the endpoint URL to specify the
+   * complete URL of the collector when paired with the POST method.
+   */
+   customPostPath?: string;
 }
 
 

--- a/tests/__tests__/configurations.test.ts
+++ b/tests/__tests__/configurations.test.ts
@@ -149,7 +149,7 @@ describe('test initValidate resolves', () => {
   test('test valid networkConfig', async () => {
     const testConfig = {
       namespace: 'sp1',
-      networkConfig: {endpoint: 'test', method: 'get'}
+      networkConfig: {endpoint: 'test', method: 'get', customPostPath: '/custom/path'}
     };
     await expect(c.initValidate(testConfig as any)).resolves.toBe(true);
   });
@@ -207,7 +207,7 @@ describe('test initValidate resolves', () => {
   test('test with all defaults', async () => {
     const testConfig = {
       namespace: 'sp1',
-      networkConfig: {endpoint: 'test', method: 'post'},
+      networkConfig: {endpoint: 'test', method: 'post', customPostPath: '/'},
       trackerConfig: {
         devicePlatform: 'mob',
         base64Encoding: true,
@@ -274,7 +274,8 @@ describe('test isValidNetworkConf', () => {
   test('valid', () => {
     const testConf = {
       endpoint: '0.0.0.0:9090',
-      method: 'post'
+      method: 'post',
+      customPostPath: '/'
     } as any;
     expect(c.isValidNetworkConf(testConf)).toBe(true);
   });

--- a/tests/__tests__/configurations.test.ts
+++ b/tests/__tests__/configurations.test.ts
@@ -149,7 +149,7 @@ describe('test initValidate resolves', () => {
   test('test valid networkConfig', async () => {
     const testConfig = {
       namespace: 'sp1',
-      networkConfig: {endpoint: 'test', method: 'get', customPostPath: '/custom/path'}
+      networkConfig: {endpoint: 'test', method: 'get', customPostPath: 'custom/path'}
     };
     await expect(c.initValidate(testConfig as any)).resolves.toBe(true);
   });
@@ -207,7 +207,7 @@ describe('test initValidate resolves', () => {
   test('test with all defaults', async () => {
     const testConfig = {
       namespace: 'sp1',
-      networkConfig: {endpoint: 'test', method: 'post', customPostPath: '/'},
+      networkConfig: {endpoint: 'test', method: 'post', customPostPath: 'com.snowplowanalytics.snowplow/tp2'},
       trackerConfig: {
         devicePlatform: 'mob',
         base64Encoding: true,
@@ -275,7 +275,7 @@ describe('test isValidNetworkConf', () => {
     const testConf = {
       endpoint: '0.0.0.0:9090',
       method: 'post',
-      customPostPath: '/'
+      customPostPath: 'com.snowplowanalytics.snowplow/tp2'
     } as any;
     expect(c.isValidNetworkConf(testConf)).toBe(true);
   });


### PR DESCRIPTION
Issue #178 

Adds the optional `customPostPath` setting to the `NetworkConfiguration` that changes the default path for POST requests to the collector.

The configuration option was already provided by the mobile native trackers, so this PR just exposes the configuration in the RN tracker configuration.