### PR TITLE
Support bare workflow in newer Expo/RN versions (close #182)

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Prepare DemoApp for Micro
       working-directory: DemoApp
-      run: perl -i -pe "s/^.*endpoint:\K.*/ \'http:\/\/10.0.2.2:9090\'\,/" App.js
+      run: perl -i -pe "s/^.*collectorEndpoint =\K.*/ \'http:\/\/10.0.2.2:9090\'\;/" App.js
 
     # -- Tracker --
     - name: Use npm cache

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Prepare DemoApp for Micro
       working-directory: DemoApp
-      run: perl -i -pe "s/^.*endpoint:\K.*/ \'http:\/\/0.0.0.0:9090\'\,/" App.js
+      run: perl -i -pe "s/^.*collectorEndpoint =\K.*/ \'http:\/\/0.0.0.0:9090\'\;/" App.js
 
     # -- Tracker --
     - name: Use npm cache

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+Version 1.3.0 (2022-10-03)
+--------------------------
+Upgrade Snowplow mobile trackers to v4 (#167)
+Add anonymous tracking features (#168)
+Add interface to subscribe for events tracked in Web views (#169)
+Add option to add custom headers (#165)
+Enable setting custom path for POST requests (#178)
+Upgrade internal and demo app dependencies (#172)
+Remove circular imports of demo app dendencies when running in demo apps (#174)
+
 Version 1.2.1 (2022-04-12)
 --------------------------
 Fix import of non-published NSDictionary helpers from SnowplowTracker on iOS (#161)

--- a/DemoApp/App.js
+++ b/DemoApp/App.js
@@ -16,15 +16,27 @@ import {
   useColorScheme,
   View,
   Button,
+  Dimensions,
 } from 'react-native';
+import {WebView} from 'react-native-webview';
 
 import {Colors, Header} from 'react-native/Libraries/NewAppScreen';
 
 import {
   createTracker,
   removeTracker,
-  // removeAllTrackers,
+  getWebViewCallback,
 } from '@snowplow/react-native-tracker';
+
+/**
+ * URI of the Snowplow collector (e.g., Micro, Mini, or BDP) to send events to
+ */
+const collectorEndpoint = 'placeholder';
+
+/**
+ * URI of a website to load in the webview component
+ */
+const webViewEndpoint = '';
 
 const Section = ({children, title}) => {
   const isDarkMode = useColorScheme() === 'dark';
@@ -62,7 +74,7 @@ const App = () => {
   const tracker = createTracker(
     'sp1',
     {
-      endpoint: 'placeholder',
+      endpoint: collectorEndpoint,
     },
     {
       trackerConfig: {
@@ -106,7 +118,7 @@ const App = () => {
   const secTracker = createTracker(
     'sp2',
     {
-      endpoint: 'placeholder',
+      endpoint: collectorEndpoint,
     },
     {
       trackerConfig: {
@@ -119,7 +131,7 @@ const App = () => {
   const anonymousTracker = createTracker(
     'sp_anon',
     {
-      endpoint: 'placeholder',
+      endpoint: collectorEndpoint,
     },
     {
       trackerConfig: {
@@ -488,6 +500,20 @@ const App = () => {
               color="#AA2222"
               accessibilityLabel="testRemove"
             />
+          </Section>
+          <Section title="Web view">
+            {webViewEndpoint ? (
+              <WebView
+                onMessage={getWebViewCallback()}
+                source={{uri: webViewEndpoint}}
+                style={{
+                  height: 400,
+                  width:
+                    Dimensions.get('window').width -
+                    styles.sectionContainer.paddingHorizontal,
+                }}
+              />
+            ) : null}
           </Section>
         </View>
       </ScrollView>

--- a/DemoApp/App.js
+++ b/DemoApp/App.js
@@ -75,6 +75,9 @@ const App = () => {
     'sp1',
     {
       endpoint: collectorEndpoint,
+      requestHeaders: {
+        test: 'works',
+      },
     },
     {
       trackerConfig: {

--- a/DemoApp/__mocks__/WebView.js
+++ b/DemoApp/__mocks__/WebView.js
@@ -1,0 +1,3 @@
+export default function WebView() {
+  return null;
+}

--- a/DemoApp/bin/app-prep-endpoint.js
+++ b/DemoApp/bin/app-prep-endpoint.js
@@ -14,8 +14,8 @@ const appFile = path.join(__dirname, '..', 'App.js');
 
 const validArg = ['android', 'ios'];
 
-const androidReplaceCmd = `perl -i -pe "s/^.*endpoint:\\K.*/ \\'http:\\/\\/${androidHost}:${microPort}\\'\\,/" ${appFile}`;
-const iosReplaceCmd = `perl -i -pe "s/^.*endpoint:\\K.*/ \\'http:\\/\\/${iosHost}:${microPort}\\'\\,/" ${appFile}`;
+const androidReplaceCmd = `perl -i -pe "s/^.*collectorEndpoint =\\K.*/ \\'http:\\/\\/${androidHost}:${microPort}\\'\\;/" ${appFile}`;
+const iosReplaceCmd = `perl -i -pe "s/^.*collectorEndpoint =\\K.*/ \\'http:\\/\\/${iosHost}:${microPort}\\'\\;/" ${appFile}`;
 
 const args = process.argv.slice(2);
 if (args.length === 1 && validArg.includes(args[0])) {

--- a/DemoApp/ios/Podfile.lock
+++ b/DemoApp/ios/Podfile.lock
@@ -286,6 +286,8 @@ PODS:
   - React-jsinspector (0.69.5)
   - React-logger (0.69.5):
     - glog
+  - react-native-webview (11.23.1):
+    - React-Core
   - React-perflogger (0.69.5)
   - React-RCTActionSheet (0.69.5):
     - React-Core/RCTActionSheetHeaders (= 0.69.5)
@@ -405,6 +407,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
+  - react-native-webview (from `../node_modules/react-native-webview`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
@@ -479,6 +482,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
+  react-native-webview:
+    :path: "../node_modules/react-native-webview"
   React-perflogger:
     :path: "../node_modules/react-native/ReactCommon/reactperflogger"
   React-RCTActionSheet:
@@ -542,6 +547,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: e42f0b46de293a026c2fb20e524d4fe09f81f575
   React-jsinspector: e385fb7a1440ae3f3b2cd1a139ca5aadaab43c10
   React-logger: 15c734997c06fe9c9b88e528fb7757601e7a56df
+  react-native-webview: d33e2db8925d090871ffeb232dfa50cb3a727581
   React-perflogger: 367418425c5e4a9f0f80385ee1eaacd2a7348f8e
   React-RCTActionSheet: e4885e7136f98ded1137cd3daccc05eaed97d5a6
   React-RCTAnimation: 7c5a74f301c9b763343ba98a3dd776ed2676993f

--- a/DemoApp/ios/Podfile.lock
+++ b/DemoApp/ios/Podfile.lock
@@ -354,7 +354,7 @@ PODS:
     - React-jsi (= 0.69.5)
     - React-logger (= 0.69.5)
     - React-perflogger (= 0.69.5)
-  - RNSnowplowTracker (1.2.1):
+  - RNSnowplowTracker (1.3.0):
     - React-Core
     - SnowplowTracker (~> 4.0)
   - SnowplowTracker (4.0.0):
@@ -560,7 +560,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 42b34fde72e42446d9b08d2b9a3ddc2fa9ac6189
   React-runtimeexecutor: c778439c3c430a5719d027d3c67423b390a221fe
   ReactCommon: ab1003b81be740fecd82509c370a45b1a7dda0c1
-  RNSnowplowTracker: 73b1dc8a265e39ec79c9771e5fd423129e6a4c90
+  RNSnowplowTracker: 4f395a9a7be502c486720f756ab6ee0d5cb33f6e
   SnowplowTracker: 2ddc6db70af5415a87ac279f044d27d140b3a2b8
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: c2b1f2494060865ac1f27e49639e72371b1205fa

--- a/DemoApp/package.json
+++ b/DemoApp/package.json
@@ -31,7 +31,8 @@
     "@jest/create-cache-key-function": "^29.0.3",
     "@snowplow/react-native-tracker": "file:..",
     "react": "18.1.0",
-    "react-native": "0.69.5"
+    "react-native": "0.69.5",
+    "react-native-webview": "11.23.1"
   },
   "devDependencies": {
     "@babel/core": "^7.19.1",
@@ -62,6 +63,9 @@
     "verbose": true,
     "transformIgnorePatterns": [
       "node_modules/(?!(@react-native|react-native|@snowplow/react-native-tracker|react-native-button)/)"
-    ]
+    ],
+    "moduleNameMapper": {
+      "react-native-webview": "<rootDir>/__mocks__/WebView.js"
+    }
   }
 }

--- a/DemoApp/package.json
+++ b/DemoApp/package.json
@@ -52,8 +52,8 @@
     "react-test-renderer": "^18.2.0",
     "rimraf": "^3.0.2",
     "shelljs": "^0.8.5",
-    "wait-on": "^6.0.1",
-    "ts-jest": "^29.0.1"
+    "ts-jest": "^29.0.1",
+    "wait-on": "^6.0.1"
   },
   "resolutions": {
     "@jest/create-cache-key-function": "^29.0.3"

--- a/DemoApp/tests/e2e/helpers/microCommands.js
+++ b/DemoApp/tests/e2e/helpers/microCommands.js
@@ -99,6 +99,7 @@ function eventsWithEventType(eventType, n = 1) {
  *     values: {
  *         testProperty: true
  *     },
+ *     header: "the: header"
  *     contexts: [{
  *         schema: "iglu:com.acme/test_context/jsonschema/1-0-0",
  *         data: {
@@ -123,11 +124,30 @@ function eventsWithProperties(eventOptions, n = 1) {
   });
 }
 
+/**
+ * Asserts on the number of events having a given HTTP request header
+ *
+ * ```
+ * eventsWithHeader("Connection: keep-alive", 2);
+ * ```
+ *
+ * @param {string} header The request header to match
+ * @param {number} [n=1] The expected number of matching events
+ */
+function eventsWithHeader(header, n = 1) {
+  n = parseInt(n, 10);
+  return getMicroGood().then(arr => {
+    const res = Micro.matchByHeader(arr, header);
+    expect(res.length).toBe(n);
+  });
+}
+
 export {
   assertNoBadEvents,
   eventsWithSchema,
   eventsWithEventType,
   eventsWithProperties,
+  eventsWithHeader,
   resetMicro,
   sleep,
 };

--- a/DemoApp/tests/e2e/helpers/microHelpers.js
+++ b/DemoApp/tests/e2e/helpers/microHelpers.js
@@ -137,6 +137,21 @@ function matchByContexts(eventsArray, expectedContextsArray) {
 }
 
 /**
+ * Filters an array of Snowplow events based on the request headers
+ *
+ * ```
+ * matchByHeader(goodEventsArray, "Connection: keep-alive");
+ *
+ * ```
+ * @param {Array} eventsArray An array of Snowplow events
+ * @param {string} header The HTTP request header to match
+ * @returns {Array} An array with the matching events
+ */
+function matchByHeader(eventsArray, header) {
+  return eventsArray.filter(hasHeader(header));
+}
+
+/**
  * Filters an array of Snowplow events based on event's Properties
  *
  * ```
@@ -155,7 +170,8 @@ function matchByContexts(eventsArray, expectedContextsArray) {
  *                 parameters: {
  *                     user_id: "tester",
  *                     name_tracker: "myTrackerName"
- *                 }
+ *                 },
+ *                 header: 'the: header',
  *             });
  * ```
  *
@@ -188,6 +204,10 @@ function matchEvents(microEvents, eventProps) {
 
   if (eventProps.parameters) {
     res = matchByParams(res, eventProps.parameters);
+  }
+
+  if (eventProps.header) {
+    res = matchByHeader(res, eventProps.header);
   }
 
   return res;
@@ -252,6 +272,12 @@ function hasContexts(expCoArr) {
   };
 }
 
+function hasHeader(header) {
+  return function (ev) {
+    return ev.rawEvent.context.headers.includes(header);
+  };
+}
+
 function keyIncludedIn(obj) {
   return function (key) {
     return Object.keys(obj).includes(key);
@@ -312,6 +338,7 @@ export {
   matchByVals,
   matchByParams,
   matchByContexts,
+  matchByHeader,
   matchEvents,
   compare,
   request,

--- a/DemoApp/tests/e2e/testEvents.micro.test.js
+++ b/DemoApp/tests/e2e/testEvents.micro.test.js
@@ -210,6 +210,7 @@ test('common in all first tracker events', async () => {
         platform: 'iot',
         name_tracker: 'sp1',
       },
+      header: 'test: works',
       contexts: [
         {schema: schemas.mobileApplicationContext},
         {schema: schemas.mobileContext},

--- a/DemoApp/yarn.lock
+++ b/DemoApp/yarn.lock
@@ -1711,7 +1711,7 @@
     "@sinonjs/commons" "^1.7.0"
 
 "@snowplow/react-native-tracker@file:..":
-  version "1.2.1"
+  version "1.3.0"
 
 "@types/babel__core@^7.1.14":
   version "7.1.18"

--- a/DemoApp/yarn.lock
+++ b/DemoApp/yarn.lock
@@ -3074,15 +3074,15 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
+escape-string-regexp@2.0.0, escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-
-escape-string-regexp@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
-  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
@@ -3968,7 +3968,7 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
-invariant@^2.2.4:
+invariant@2.2.4, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -6118,6 +6118,14 @@ react-native-gradle-plugin@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.7.tgz#96602f909745239deab7b589443f14fce5da2056"
   integrity sha512-+4JpbIx42zGTONhBTIXSyfyHICHC29VTvhkkoUOJAh/XHPEixpuBduYgf6Y4y9wsN1ARlQhBBoptTvXvAFQf5g==
+
+react-native-webview@11.23.1:
+  version "11.23.1"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.23.1.tgz#6a4bf2620e491dd4fecf4e6dc079005117fae12c"
+  integrity sha512-bmqsdg4RYOUYD37R9XTrQALm7eD62KbLNPRfgvpLGd1SjaurvAjjsLrLN4mt6yOtKOMKeZvlcAl3x6De6cCQsA==
+  dependencies:
+    escape-string-regexp "2.0.0"
+    invariant "2.2.4"
 
 react-native@0.69.5:
   version "0.69.5"

--- a/DemoAppTV/ios/Podfile.lock
+++ b/DemoAppTV/ios/Podfile.lock
@@ -249,7 +249,7 @@ PODS:
     - React-jsi (= 0.66.3-1)
     - React-logger (= 0.66.3-1)
     - React-perflogger (= 0.66.3-1)
-  - RNSnowplowTracker (1.2.1):
+  - RNSnowplowTracker (1.3.0):
     - React-Core
     - SnowplowTracker (~> 4.0)
   - SnowplowTracker (4.0.0):
@@ -387,7 +387,7 @@ SPEC CHECKSUMS:
   React-RCTText: 2d5191e551df3e74dbf27f71c2785081aaba4299
   React-runtimeexecutor: 04662d38a5b1fae4f8a0b5bf517946d0e7d6721a
   ReactCommon: 67042925ef6455377bb5edbc8d5c631a89dab901
-  RNSnowplowTracker: 73b1dc8a265e39ec79c9771e5fd423129e6a4c90
+  RNSnowplowTracker: 4f395a9a7be502c486720f756ab6ee0d5cb33f6e
   SnowplowTracker: 2ddc6db70af5415a87ac279f044d27d140b3a2b8
   Yoga: 56a884d4fa5c2f709125202018f44ea7b6e901a2
 

--- a/android/src/main/java/com/snowplowanalytics/react/tracker/RNSnowplowTrackerModule.java
+++ b/android/src/main/java/com/snowplowanalytics/react/tracker/RNSnowplowTrackerModule.java
@@ -137,7 +137,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                               Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             promise.resolve(Snowplow.removeTracker(trackerController));
 
@@ -165,7 +165,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             ReadableMap argmap = details.getMap("eventData");
             ReadableArray contexts = details.getArray("contexts");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             SelfDescribingJson sdj = EventUtil.createSelfDescribingJson(argmap);
             SelfDescribing event = new SelfDescribing(sdj);
@@ -189,7 +189,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             ReadableMap argmap = details.getMap("eventData");
             ReadableArray contexts = details.getArray("contexts");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             Structured event = EventUtil.createStructuredEvent(argmap);
 
@@ -212,7 +212,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             ReadableMap argmap = details.getMap("eventData");
             ReadableArray contexts = details.getArray("contexts");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             ScreenView event = EventUtil.createScreenViewEvent(argmap);
 
@@ -235,7 +235,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             ReadableMap argmap = details.getMap("eventData");
             ReadableArray contexts = details.getArray("contexts");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             PageView event = EventUtil.createPageViewEvent(argmap);
 
@@ -258,7 +258,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             ReadableMap argmap = details.getMap("eventData");
             ReadableArray contexts = details.getArray("contexts");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             Timing event = EventUtil.createTimingEvent(argmap);
 
@@ -281,7 +281,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             ReadableMap argmap = details.getMap("eventData");
             ReadableArray contexts = details.getArray("contexts");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             ConsentGranted event = EventUtil.createConsentGrantedEvent(argmap);
 
@@ -304,7 +304,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             ReadableMap argmap = details.getMap("eventData");
             ReadableArray contexts = details.getArray("contexts");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             ConsentWithdrawn event = EventUtil.createConsentWithdrawnEvent(argmap);
 
@@ -327,7 +327,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             ReadableMap argmap = details.getMap("eventData");
             ReadableArray contexts = details.getArray("contexts");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             EcommerceTransaction event = EventUtil.createEcommerceTransactionEvent(argmap);
 
@@ -350,7 +350,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             ReadableMap argmap = details.getMap("eventData");
             ReadableArray contexts = details.getArray("contexts");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             DeepLinkReceived event = EventUtil.createDeepLinkReceivedEvent(argmap);
 
@@ -373,7 +373,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             ReadableMap argmap = details.getMap("eventData");
             ReadableArray contexts = details.getArray("contexts");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             MessageNotification event = EventUtil.createMessageNotificationEvent(argmap);
 
@@ -395,7 +395,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             String namespace = details.getString("tracker");
             String tag = details.getString("removeTag");
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             trackerController.getGlobalContexts().remove(tag);
             promise.resolve(true);
@@ -422,7 +422,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             }
             GlobalContext gcStatic = new GlobalContext(staticContexts);
 
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             trackerController.getGlobalContexts().add(tag, gcStatic);
             promise.resolve(true);
@@ -437,7 +437,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                           Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             if (details.isNull("userId")) {
                 trackerController.getSubject().setUserId(null);
@@ -456,7 +456,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                                  Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             if (details.isNull("networkUserId")) {
                 trackerController.getSubject().setNetworkUserId(null);
@@ -475,7 +475,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                                 Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             if (details.isNull("domainUserId")) {
                 trackerController.getSubject().setDomainUserId(null);
@@ -494,7 +494,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                              Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             if (details.isNull("ipAddress")) {
                 trackerController.getSubject().setIpAddress(null);
@@ -513,7 +513,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                              Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             if (details.isNull("useragent")) {
                 trackerController.getSubject().setUseragent(null);
@@ -532,7 +532,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                             Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             if (details.isNull("timezone")) {
                 trackerController.getSubject().setTimezone(null);
@@ -551,7 +551,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                             Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             if (details.isNull("language")) {
                 trackerController.getSubject().setLanguage(null);
@@ -570,7 +570,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                                     Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             if (details.isNull("screenResolution")) {
                 trackerController.getSubject().setScreenResolution(null);
@@ -594,7 +594,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                                   Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             if (details.isNull("screenViewport")) {
                 trackerController.getSubject().setScreenViewPort(null);
@@ -618,7 +618,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                               Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             if (details.isNull("colorDepth")) {
                 trackerController.getSubject().setColorDepth(null);
@@ -637,7 +637,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                                  Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             String suid = trackerController.getSession().getUserId();
             promise.resolve(suid);
@@ -651,7 +651,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                              Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             String sid = trackerController.getSession().getSessionId();
             promise.resolve(sid);
@@ -665,7 +665,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                                 Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             int sidx = trackerController.getSession().getSessionIndex();
             promise.resolve(sidx);
@@ -679,7 +679,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                                   Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             boolean isInBg = trackerController.getSession().isInBackground();
             promise.resolve(isInBg);
@@ -693,7 +693,7 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                                    Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             int bgIdx = trackerController.getSession().getBackgroundIndex();
             promise.resolve(bgIdx);
@@ -707,13 +707,17 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
                                    Promise promise) {
         try {
             String namespace = details.getString("tracker");
-            TrackerController trackerController = Snowplow.getTracker(namespace);
+            TrackerController trackerController = getTracker(namespace);
 
             int fgIdx = trackerController.getSession().getForegroundIndex();
             promise.resolve(fgIdx);
         } catch(Throwable t) {
             promise.reject("ERROR", t.getMessage());
         }
+    }
+
+    private TrackerController getTracker(String namespace) {
+        return namespace == null ? Snowplow.getDefaultTracker() : Snowplow.getTracker(namespace);
     }
 
 }

--- a/android/src/main/java/com/snowplowanalytics/react/tracker/RNSnowplowTrackerModule.java
+++ b/android/src/main/java/com/snowplowanalytics/react/tracker/RNSnowplowTrackerModule.java
@@ -73,6 +73,10 @@ public class RNSnowplowTrackerModule extends ReactContextBaseJavaModule {
             } else {
                 networkConfiguration = new NetworkConfiguration(networkConfig.getString("endpoint"));
             }
+            if (networkConfig.hasKey("customPostPath") && !networkConfig.isNull("customPostPath")) {
+                String customPostPath = networkConfig.getString("customPostPath");
+                networkConfiguration.customPostPath = customPostPath;
+            }
 
             // Configurations
             List<Configuration> controllers = new ArrayList<Configuration>();

--- a/android/src/main/java/com/snowplowanalytics/react/util/TrackerVersion.java
+++ b/android/src/main/java/com/snowplowanalytics/react/util/TrackerVersion.java
@@ -2,6 +2,6 @@ package com.snowplowanalytics.react.util;
 
 public class TrackerVersion {
 
-    public final static String RN_TRACKER_VERSION = "rn-1.2.1";
+    public final static String RN_TRACKER_VERSION = "rn-1.3.0";
 
 }

--- a/ios/RNSnowplowTracker.h
+++ b/ios/RNSnowplowTracker.h
@@ -18,10 +18,10 @@
 //  License: Apache License Version 2.0
 //
 
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
 #endif
 
 #import <Foundation/Foundation.h>

--- a/ios/RNSnowplowTracker.m
+++ b/ios/RNSnowplowTracker.m
@@ -63,6 +63,10 @@ RCT_EXPORT_METHOD(createTracker:
     NSString *method = [networkConfig rnsp_stringForKey:@"method" defaultValue:nil];
     SPHttpMethod httpMethod = [@"get" isEqualToString:method] ? SPHttpMethodGet : SPHttpMethodPost;
     SPNetworkConfiguration *networkConfiguration = [[SPNetworkConfiguration alloc] initWithEndpoint:networkConfig[@"endpoint"] method:httpMethod];
+    NSString *customPostPath = [networkConfig rnsp_stringForKey:@"customPostPath" defaultValue:nil];
+    if (customPostPath != nil) {
+        networkConfiguration.customPostPath = customPostPath;
+    }
 
     // Configurations
     NSMutableArray *controllers = [NSMutableArray array];

--- a/ios/RNSnowplowTracker.m
+++ b/ios/RNSnowplowTracker.m
@@ -123,7 +123,7 @@ RCT_EXPORT_METHOD(removeTracker: (NSDictionary *)details
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
     BOOL removed = [SPSnowplow removeTracker:trackerController];
     resolve(@(removed));
 }
@@ -138,7 +138,7 @@ RCT_EXPORT_METHOD(trackSelfDescribingEvent:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *argmap = [details objectForKey:@"eventData"];
@@ -162,7 +162,7 @@ RCT_EXPORT_METHOD(trackStructuredEvent:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *argmap = [details objectForKey:@"eventData"];
@@ -199,7 +199,7 @@ RCT_EXPORT_METHOD(trackScreenViewEvent:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *argmap = [details objectForKey:@"eventData"];
@@ -250,7 +250,7 @@ RCT_EXPORT_METHOD(trackPageViewEvent:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *argmap = [details objectForKey:@"eventData"];
@@ -282,7 +282,7 @@ RCT_EXPORT_METHOD(trackTimingEvent:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *argmap = [details objectForKey:@"eventData"];
@@ -313,7 +313,7 @@ RCT_EXPORT_METHOD(trackConsentGrantedEvent:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *argmap = [details objectForKey:@"eventData"];
@@ -349,7 +349,7 @@ RCT_EXPORT_METHOD(trackConsentWithdrawnEvent:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *argmap = [details objectForKey:@"eventData"];
@@ -386,7 +386,7 @@ RCT_EXPORT_METHOD(trackEcommerceTransactionEvent:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *argmap = [details objectForKey:@"eventData"];
@@ -439,7 +439,7 @@ RCT_EXPORT_METHOD(trackDeepLinkReceivedEvent:
             resolver:(RCTPromiseResolveBlock)resolve
             rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *argmap = [details objectForKey:@"eventData"];
@@ -467,7 +467,7 @@ RCT_EXPORT_METHOD(trackMessageNotificationEvent:
             resolver:(RCTPromiseResolveBlock)resolve
             rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *argmap = [details objectForKey:@"eventData"];
@@ -581,7 +581,7 @@ RCT_EXPORT_METHOD(removeGlobalContexts:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSString *tag = [details objectForKey:@"removeTag"];
@@ -598,7 +598,7 @@ RCT_EXPORT_METHOD(addGlobalContexts:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSDictionary *gcArg = [details objectForKey:@"addGlobalContext"];
@@ -621,7 +621,7 @@ RCT_EXPORT_METHOD(setUserId:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSString *newUid = [details rnsp_stringForKey:@"userId" defaultValue:nil];
@@ -638,7 +638,7 @@ RCT_EXPORT_METHOD(setNetworkUserId:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSString *newNuid = [details rnsp_stringForKey:@"networkUserId" defaultValue:nil];
@@ -655,7 +655,7 @@ RCT_EXPORT_METHOD(setDomainUserId:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSString *newDuid = [details rnsp_stringForKey:@"domainUserId" defaultValue:nil];
@@ -672,7 +672,7 @@ RCT_EXPORT_METHOD(setIpAddress:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSString *newIp = [details rnsp_stringForKey:@"ipAddress" defaultValue:nil];
@@ -689,7 +689,7 @@ RCT_EXPORT_METHOD(setUseragent:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSString *newUagent = [details rnsp_stringForKey:@"useragent" defaultValue:nil];
@@ -706,7 +706,7 @@ RCT_EXPORT_METHOD(setTimezone:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSString *newTz = [details rnsp_stringForKey:@"timezone" defaultValue:nil];
@@ -723,7 +723,7 @@ RCT_EXPORT_METHOD(setLanguage:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSString *newLang = [details rnsp_stringForKey:@"language" defaultValue:nil];
@@ -740,7 +740,7 @@ RCT_EXPORT_METHOD(setScreenResolution:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSObject *newRes = [details objectForKey:@"screenResolution"];
@@ -764,7 +764,7 @@ RCT_EXPORT_METHOD(setScreenViewport:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSObject *newView = [details objectForKey:@"screenViewport"];
@@ -788,7 +788,7 @@ RCT_EXPORT_METHOD(setColorDepth:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSNumber *newColorD = [details rnsp_numberForKey:@"colorDepth" defaultValue:nil];
@@ -805,7 +805,7 @@ RCT_EXPORT_METHOD(getSessionUserId:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSString *suid = [trackerController.session userId];
@@ -821,7 +821,7 @@ RCT_EXPORT_METHOD(getSessionId:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSString *sid = [trackerController.session sessionId];
@@ -837,7 +837,7 @@ RCT_EXPORT_METHOD(getSessionIndex:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSInteger sidx = [trackerController.session sessionIndex];
@@ -853,7 +853,7 @@ RCT_EXPORT_METHOD(getIsInBackground:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         BOOL isInBg = [trackerController.session isInBackground];
@@ -869,7 +869,7 @@ RCT_EXPORT_METHOD(getBackgroundIndex:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSInteger bgIdx = [trackerController.session backgroundIndex];
@@ -885,7 +885,7 @@ RCT_EXPORT_METHOD(getForegroundIndex:
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSString *namespace = [details objectForKey:@"tracker"];
-    id<SPTrackerController> trackerController = [SPSnowplow trackerByNamespace:namespace];
+    id<SPTrackerController> trackerController = [self trackerByNamespace:namespace];
 
     if (trackerController != nil) {
         NSInteger fgIdx = [trackerController.session foregroundIndex];
@@ -894,6 +894,10 @@ RCT_EXPORT_METHOD(getForegroundIndex:
         NSError* error = [NSError errorWithDomain:@"SnowplowTracker" code:200 userInfo:nil];
         reject(@"ERROR", @"tracker with given namespace not found", error);
     }
+}
+
+- (nullable id<SPTrackerController>)trackerByNamespace:(NSString *)namespace {
+    return [namespace isEqual:[NSNull null]] ? [SPSnowplow defaultTracker] : [SPSnowplow trackerByNamespace:namespace];
 }
 
 @end

--- a/ios/RNSnowplowTracker.m
+++ b/ios/RNSnowplowTracker.m
@@ -67,20 +67,24 @@ RCT_EXPORT_METHOD(createTracker:
     if (customPostPath != nil) {
         networkConfiguration.customPostPath = customPostPath;
     }
+    NSObject *requestHeaders = [networkConfig objectForKey:@"requestHeaders"];
+    if (requestHeaders != nil && [requestHeaders isKindOfClass:NSDictionary.class]) {
+        networkConfiguration.requestHeaders = (NSDictionary *)requestHeaders;
+    }
 
     // Configurations
     NSMutableArray *controllers = [NSMutableArray array];
 
     // TrackerConfiguration
     NSObject *trackerArg = [argmap objectForKey:@"trackerConfig"];
-    if (trackerArg !=nil && [trackerArg isKindOfClass:NSDictionary.class]) {
+    if (trackerArg != nil && [trackerArg isKindOfClass:NSDictionary.class]) {
         SPTrackerConfiguration *trackerConfiguration = [RNConfigUtils mkTrackerConfig:(NSDictionary *)trackerArg];
         [controllers addObject:trackerConfiguration];
     }
 
     // SessionConfiguration
     NSObject *sessionArg = [argmap objectForKey:@"sessionConfig"];
-    if (sessionArg !=nil && [sessionArg isKindOfClass:NSDictionary.class]) {
+    if (sessionArg != nil && [sessionArg isKindOfClass:NSDictionary.class]) {
         SPSessionConfiguration *sessionConfiguration = [RNConfigUtils mkSessionConfig:(NSDictionary *)sessionArg];
         [controllers addObject:sessionConfiguration];
     }

--- a/ios/RNSnowplowTracker.xcodeproj/project.pbxproj
+++ b/ios/RNSnowplowTracker.xcodeproj/project.pbxproj
@@ -8,8 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		0562F54E146600A44BDEF45D /* libPods-RNSnowplowTracker.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E15379B78A468FF69B0BDCA /* libPods-RNSnowplowTracker.a */; };
-		75D5EB7C2293B157005C8629 /* RCTConvert+Snowplow.m in Sources */ = {isa = PBXBuildFile; fileRef = 75D5EB7B2293B157005C8629 /* RCTConvert+Snowplow.m */; };
-		75D5EB7E2293B206005C8629 /* RCTConvert+Snowplow.h in Headers */ = {isa = PBXBuildFile; fileRef = 75D5EB7A2293B157005C8629 /* RCTConvert+Snowplow.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		75D5EB7F2293B206005C8629 /* RNSnowplowTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = B3E7B5881CC2AC0600A0062D /* RNSnowplowTracker.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		B3E7B58A1CC2AC0600A0062D /* RNSnowplowTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RNSnowplowTracker.m */; };
 /* End PBXBuildFile section */
@@ -29,8 +27,6 @@
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libRNSnowplowTracker.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNSnowplowTracker.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		4D25182CF98251495D063E8A /* Pods-RNSnowplowTracker.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNSnowplowTracker.release.xcconfig"; path = "Target Support Files/Pods-RNSnowplowTracker/Pods-RNSnowplowTracker.release.xcconfig"; sourceTree = "<group>"; };
-		75D5EB7A2293B157005C8629 /* RCTConvert+Snowplow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+Snowplow.h"; sourceTree = "<group>"; };
-		75D5EB7B2293B157005C8629 /* RCTConvert+Snowplow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RCTConvert+Snowplow.m"; sourceTree = "<group>"; };
 		7D2A97B8BEC452B270B0AA54 /* Pods-RNSnowplowTracker.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNSnowplowTracker.debug.xcconfig"; path = "Target Support Files/Pods-RNSnowplowTracker/Pods-RNSnowplowTracker.debug.xcconfig"; sourceTree = "<group>"; };
 		8E15379B78A468FF69B0BDCA /* libPods-RNSnowplowTracker.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNSnowplowTracker.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3E7B5881CC2AC0600A0062D /* RNSnowplowTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNSnowplowTracker.h; sourceTree = "<group>"; };
@@ -68,8 +64,6 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
-				75D5EB7A2293B157005C8629 /* RCTConvert+Snowplow.h */,
-				75D5EB7B2293B157005C8629 /* RCTConvert+Snowplow.m */,
 				B3E7B5881CC2AC0600A0062D /* RNSnowplowTracker.h */,
 				B3E7B5891CC2AC0600A0062D /* RNSnowplowTracker.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
@@ -94,7 +88,6 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				75D5EB7E2293B206005C8629 /* RCTConvert+Snowplow.h in Headers */,
 				75D5EB7F2293B206005C8629 /* RNSnowplowTracker.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -183,7 +176,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				75D5EB7C2293B157005C8629 /* RCTConvert+Snowplow.m in Sources */,
 				B3E7B58A1CC2AC0600A0062D /* RNSnowplowTracker.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Util/RNTrackerVersion.m
+++ b/ios/Util/RNTrackerVersion.m
@@ -22,6 +22,6 @@
 
 @implementation RNTrackerVersion
 
-NSString * const kRNTrackerVersion = @"rn-1.2.1";
+NSString * const kRNTrackerVersion = @"rn-1.3.0";
 
 @end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@snowplow/react-native-tracker",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@snowplow/react-native-tracker",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^28.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowplow/react-native-tracker",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A library for tracking Snowplow events in React Native",
   "homepage": "https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/react-native-tracker/",
   "main": "dist/index.js",

--- a/src/configurations.ts
+++ b/src/configurations.ts
@@ -36,6 +36,7 @@ const networkProps = [
   'endpoint',
   'method',
   'customPostPath',
+  'requestHeaders',
 ];
 const trackerProps= [
   'appId',

--- a/src/configurations.ts
+++ b/src/configurations.ts
@@ -32,7 +32,11 @@ import type {
 /**
  * Configuration properties
  */
-const networkProps = ['endpoint', 'method'];
+const networkProps = [
+  'endpoint',
+  'method',
+  'customPostPath',
+];
 const trackerProps= [
   'appId',
   'devicePlatform',

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import type {
   TrackerControllerConfiguration,
   ReactNativeTracker
 } from './types';
+import { getWebViewCallback } from './webViewInterface';
 
 /**
  * Creates a React Native Tracker object
@@ -143,6 +144,7 @@ export {
   createTracker,
   removeTracker,
   removeAllTrackers,
+  getWebViewCallback,
 };
 
 export type {

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -51,7 +51,7 @@ import type {
  * @returns {Promise}
  */
 function trackSelfDescribingEvent(
-  namespace: string,
+  namespace: string | null,
   argmap: SelfDescribing,
   contexts: EventContext[] = []
 ): Promise<void> {
@@ -77,7 +77,7 @@ function trackSelfDescribingEvent(
  * @returns {Promise}
  */
 function trackScreenViewEvent(
-  namespace: string,
+  namespace: string | null,
   argmap: ScreenViewProps,
   contexts: EventContext[] = []
 ): Promise<void> {
@@ -102,7 +102,7 @@ function trackScreenViewEvent(
  * @returns {Promise}
  */
 function trackStructuredEvent(
-  namespace: string,
+  namespace: string | null,
   argmap: StructuredProps,
   contexts: EventContext[] = []
 ): Promise<void> {
@@ -127,7 +127,7 @@ function trackStructuredEvent(
  * @returns {Promise}
  */
 function trackPageViewEvent(
-  namespace: string,
+  namespace: string | null,
   argmap: PageViewProps,
   contexts: EventContext[] = []
 ): Promise<void> {
@@ -152,7 +152,7 @@ function trackPageViewEvent(
  * @returns {Promise}
  */
 function trackTimingEvent(
-  namespace: string,
+  namespace: string | null,
   argmap: TimingProps,
   contexts: EventContext[] = []
 ): Promise<void> {
@@ -177,7 +177,7 @@ function trackTimingEvent(
  * @returns {Promise}
  */
 function trackConsentGrantedEvent(
-  namespace: string,
+  namespace: string | null,
   argmap: ConsentGrantedProps,
   contexts: EventContext[] = []
 ): Promise<void> {
@@ -202,7 +202,7 @@ function trackConsentGrantedEvent(
  * @returns {Promise}
  */
 function trackConsentWithdrawnEvent(
-  namespace: string,
+  namespace: string | null,
   argmap: ConsentWithdrawnProps,
   contexts: EventContext[] = []
 ): Promise<void> {
@@ -227,7 +227,7 @@ function trackConsentWithdrawnEvent(
  * @returns {Promise}
  */
 function trackEcommerceTransactionEvent(
-  namespace: string,
+  namespace: string | null,
   argmap: EcommerceTransactionProps,
   contexts: EventContext[] = []
 ): Promise<void> {
@@ -252,7 +252,7 @@ function trackEcommerceTransactionEvent(
  * @returns {Promise}
  */
 function trackDeepLinkReceivedEvent(
-  namespace: string,
+  namespace: string | null,
   argmap: DeepLinkReceivedProps,
   contexts: EventContext[] = []
 ): Promise<void> {
@@ -277,7 +277,7 @@ function trackDeepLinkReceivedEvent(
  * @returns {Promise}
  */
 function trackMessageNotificationEvent(
-  namespace: string,
+  namespace: string | null,
   argmap: MessageNotificationProps,
   contexts: EventContext[] = []
 ): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,7 +89,12 @@ export interface NetworkConfiguration {
    * 
    * @defaultValue `com.snowplowanalytics.snowplow/tp2`.
    */
-   customPostPath?: string;
+  customPostPath?: string;
+
+  /**
+   * Custom headers for HTTP requests to the Collector.
+   */
+  requestHeaders?: Record<string, string>;
 }
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,14 @@ export interface NetworkConfiguration {
    * @defaultValue 'post'
    */
   method?: HttpMethod;
+
+  /**
+   * A custom path which will be added to the endpoint URL to specify the
+   * complete URL of the collector when paired with the POST method.
+   * 
+   * @defaultValue `com.snowplowanalytics.snowplow/tp2`.
+   */
+   customPostPath?: string;
 }
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -912,3 +912,26 @@ export type ReactNativeTracker = {
    */
   readonly getForegroundIndex: () => Promise<number | undefined>;
 };
+
+/**
+ * Internal event type for page views tracked using the WebView tracker.
+ */
+export interface WebViewPageViewEvent {
+  title?: string | null;
+  url?: string;
+  referrer?: string;
+}
+
+/**
+ * Internal type exchanged in messages received from the WebView tracker in Web views through the web view callback.
+ */
+export type WebViewMessage = {
+  command:
+    | 'trackSelfDescribingEvent'
+    | 'trackStructEvent'
+    | 'trackPageView'
+    | 'trackScreenView';
+  event: StructuredProps | SelfDescribing | ScreenViewProps | WebViewPageViewEvent;
+  context?: Array<SelfDescribing> | null;
+  trackers?: Array<string>;
+};

--- a/src/webViewInterface.ts
+++ b/src/webViewInterface.ts
@@ -1,0 +1,89 @@
+import {
+  trackPageViewEvent,
+  trackScreenViewEvent,
+  trackSelfDescribingEvent,
+  trackStructuredEvent,
+} from './tracker';
+import type {
+  ScreenViewProps,
+  SelfDescribing,
+  StructuredProps,
+  WebViewPageViewEvent,
+  WebViewMessage,
+} from './types';
+
+function forEachTracker(
+  trackers: Array<string> | undefined,
+  iterator: (namespace: string | null) => void
+): void {
+  if (trackers) {
+    trackers.forEach(iterator);
+  } else {
+    iterator(null);
+  }
+}
+
+/**
+ * Enables tracking events from apps rendered in react-native-webview components.
+ * The apps need to use the Snowplow WebView tracker to track the events.
+ * 
+ * To subscribe for the events, set the `onMessage` attribute:
+ * <WebView onMessage={getWebViewCallback()} ... />
+ * 
+ * @returns Callback to subscribe for events from Web views tracked using the Snowplow WebView tracker.
+ */
+export function getWebViewCallback() {
+  return (message: { nativeEvent: { data: string } }): void => {
+    const data = JSON.parse(message.nativeEvent.data) as WebViewMessage;
+    switch (data.command) {
+    case 'trackSelfDescribingEvent':
+      forEachTracker(data.trackers, (namespace) => {
+        trackSelfDescribingEvent(
+          namespace,
+            data.event as SelfDescribing,
+            data.context || []
+        ).catch((error) => {
+          console.error(error);
+        });
+      });
+      break;
+
+    case 'trackStructEvent':
+      forEachTracker(data.trackers, (namespace) => {
+        trackStructuredEvent(
+          namespace,
+            data.event as StructuredProps,
+            data.context || []
+        ).catch((error) => {
+          console.error(error);
+        });
+      });
+      break;
+
+    case 'trackPageView':
+      forEachTracker(data.trackers, (namespace) => {
+        const event = data.event as WebViewPageViewEvent;
+        trackPageViewEvent(namespace, {
+          pageTitle: event.title ?? '',
+          pageUrl: event.url ?? '',
+          referrer: event.referrer,
+        }).catch((error) => {
+          console.error(error);
+        });
+      });
+      break;
+
+    case 'trackScreenView':
+      forEachTracker(data.trackers, (namespace) => {
+        trackScreenViewEvent(
+          namespace,
+            data.event as ScreenViewProps,
+            data.context || []
+        ).catch((error) => {
+          console.error(error);
+        });
+      });
+      break;
+    }
+  };
+}

--- a/tests/__tests__/configurations.test.ts
+++ b/tests/__tests__/configurations.test.ts
@@ -149,7 +149,7 @@ describe('test initValidate resolves', () => {
   test('test valid networkConfig', async () => {
     const testConfig = {
       namespace: 'sp1',
-      networkConfig: {endpoint: 'test', method: 'get', customPostPath: 'custom/path'}
+      networkConfig: {endpoint: 'test', method: 'get', customPostPath: 'custom/path', requestHeaders: {the: 'header'}}
     };
     await expect(c.initValidate(testConfig as any)).resolves.toBe(true);
   });

--- a/tests/__tests__/configurations.test.ts
+++ b/tests/__tests__/configurations.test.ts
@@ -149,7 +149,7 @@ describe('test initValidate resolves', () => {
   test('test valid networkConfig', async () => {
     const testConfig = {
       namespace: 'sp1',
-      networkConfig: {endpoint: 'test', method: 'get'}
+      networkConfig: {endpoint: 'test', method: 'get', customPostPath: 'custom/path'}
     };
     await expect(c.initValidate(testConfig as any)).resolves.toBe(true);
   });
@@ -207,7 +207,7 @@ describe('test initValidate resolves', () => {
   test('test with all defaults', async () => {
     const testConfig = {
       namespace: 'sp1',
-      networkConfig: {endpoint: 'test', method: 'post'},
+      networkConfig: {endpoint: 'test', method: 'post', customPostPath: 'com.snowplowanalytics.snowplow/tp2'},
       trackerConfig: {
         devicePlatform: 'mob',
         base64Encoding: true,
@@ -274,7 +274,8 @@ describe('test isValidNetworkConf', () => {
   test('valid', () => {
     const testConf = {
       endpoint: '0.0.0.0:9090',
-      method: 'post'
+      method: 'post',
+      customPostPath: 'com.snowplowanalytics.snowplow/tp2'
     } as any;
     expect(c.isValidNetworkConf(testConf)).toBe(true);
   });


### PR DESCRIPTION
Disclaimer: to be honest, I do not fully understand why it only works this way.

I am building an app with RN 0.68.2 and Expo 45. I wanted to install the Snowplow package but the builds for iOS fail with this error (besides for `RCTBundleManager` also for a few others):

```
Duplicate interface definition for class 'RCTBundleManager'

in file included from [...]/node_modules/@snowplow/react-native-tracker/ios/RNSnowplowTracker.m:21:
in file included from [...]/node_modules/@snowplow/react-native-tracker/ios/RNSnowplowTracker.h:28:
```

Based on what I learned from similar issues in other packages I have made the changes in this PR and tested them with my app.

- https://github.com/expo/expo/issues/15649
- https://github.com/expo/expo/issues/15622
- https://github.com/segmentio/analytics-react-native/pull/434