### PR TITLE
Bump Snowplow native tracker dependency to 4.1

### DIFF
--- a/DemoApp/ios/Podfile.lock
+++ b/DemoApp/ios/Podfile.lock
@@ -357,7 +357,7 @@ PODS:
   - RNSnowplowTracker (1.3.0):
     - React-Core
     - SnowplowTracker (~> 4.0)
-  - SnowplowTracker (4.0.0):
+  - SnowplowTracker (4.1.0):
     - FMDB (~> 2.7)
   - SocketRocket (0.6.0)
   - Yoga (1.14.0)
@@ -561,7 +561,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: c778439c3c430a5719d027d3c67423b390a221fe
   ReactCommon: ab1003b81be740fecd82509c370a45b1a7dda0c1
   RNSnowplowTracker: 4f395a9a7be502c486720f756ab6ee0d5cb33f6e
-  SnowplowTracker: 2ddc6db70af5415a87ac279f044d27d140b3a2b8
+  SnowplowTracker: 3f35a60dcb2cf9c4a56fa4cad46d5af6d1b5db44
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: c2b1f2494060865ac1f27e49639e72371b1205fa
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/DemoAppTV/ios/Podfile.lock
+++ b/DemoAppTV/ios/Podfile.lock
@@ -252,7 +252,7 @@ PODS:
   - RNSnowplowTracker (1.3.0):
     - React-Core
     - SnowplowTracker (~> 4.0)
-  - SnowplowTracker (4.0.0):
+  - SnowplowTracker (4.1.0):
     - FMDB (~> 2.7)
   - Yoga (1.14.0)
 
@@ -388,7 +388,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 04662d38a5b1fae4f8a0b5bf517946d0e7d6721a
   ReactCommon: 67042925ef6455377bb5edbc8d5c631a89dab901
   RNSnowplowTracker: 4f395a9a7be502c486720f756ab6ee0d5cb33f6e
-  SnowplowTracker: 2ddc6db70af5415a87ac279f044d27d140b3a2b8
+  SnowplowTracker: 3f35a60dcb2cf9c4a56fa4cad46d5af6d1b5db44
   Yoga: 56a884d4fa5c2f709125202018f44ea7b6e901a2
 
 PODFILE CHECKSUM: 5492a106d2c554b63f3abd57277e2d2cce6fe1d3

--- a/RNSnowplowTracker.podspec
+++ b/RNSnowplowTracker.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency "SnowplowTracker", "~> 4.0"
+  s.dependency "SnowplowTracker", "~> 4.1"
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,5 +50,5 @@ dependencies {
     // Required Dependency for the Tracker
     implementation "com.squareup.okhttp3:okhttp:4.9.3"
     implementation "com.facebook.react:react-native:+"
-    implementation 'com.snowplowanalytics:snowplow-android-tracker:4.0.+'
+    implementation 'com.snowplowanalytics:snowplow-android-tracker:4.1.+'
 }


### PR DESCRIPTION
Bump the underlying Snowplow native trackers from v4.0 to v4.1.