### PR TITLE
Release/1.4.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,11 +49,13 @@ jobs:
       env:
         IOS_VER_FILEPATH: 'ios/Util/RNTrackerVersion.m'
         ANDR_VER_FILEPATH: 'android/src/main/java/com/snowplowanalytics/react/util/TrackerVersion.java'
+        JS_VER_FILEPATH: 'src/jsCore.ts'
       run: |
         echo ::set-output name=TAG_VERSION::${GITHUB_REF#refs/*/}
         echo "##[set-output name=RN_TRACKER_VERSION;]$(node -p "require('./package.json').version")"
         echo "##[set-output name=RN_IOS_TRACKER_VERSION;]$(cat "${IOS_VER_FILEPATH}" | sed -n -e 's/^.*kRNTrackerVersion = @"rn-\(.*\)";/\1/p')"
         echo "##[set-output name=RN_ANDROID_TRACKER_VERSION;]$(cat "${ANDR_VER_FILEPATH}" | sed -n -e 's/^.*RN_TRACKER_VERSION = "rn-\(.*\)";/\1/p')"
+        echo "##[set-output name=RN_JS_TRACKER_VERSION;]$(cat "${JS_VER_FILEPATH}" | sed -n -e 's/^.*trackerVersion = '\''rn-\(.*\)'\'';/\1/p')"
 
     - name: Fail if version mismatch
       run: |
@@ -67,6 +69,10 @@ jobs:
         fi
         if [ "${{ steps.version.outputs.TAG_VERSION }}" != "${{ steps.version.outputs.RN_ANDROID_TRACKER_VERSION }}" ] ; then
           echo "Tag version (${{ steps.version.outputs.TAG_VERSION }}) doesn't match version in project(android) (${{ steps.version.outputs.RN_ANDROID_TRACKER_VERSION }})"
+          exit 1
+        fi
+        if [ "${{ steps.version.outputs.TAG_VERSION }}" != "${{ steps.version.outputs.RN_JS_TRACKER_VERSION }}" ] ; then
+          echo "Tag version (${{ steps.version.outputs.TAG_VERSION }}) doesn't match version in project(js) (${{ steps.version.outputs.RN_JS_TRACKER_VERSION }})"
           exit 1
         fi
 

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Get micro
       if: steps.cache-micro.outputs.cache-hit != 'true'
-      run: curl -o micro.jar -L https://github.com/snowplow-incubator/snowplow-micro/releases/download/micro-1.3.3/snowplow-micro-1.3.3.jar
+      run: curl -o micro.jar -L https://github.com/snowplow-incubator/snowplow-micro/releases/download/micro-1.4.0/snowplow-micro-1.4.0.jar
 
     - name: Run Micro in background
       run: java -jar micro.jar --collector-config DemoApp/tests/micro/micro.conf --iglu DemoApp/tests/micro/iglu.json &

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Get micro
       if: steps.cache-micro.outputs.cache-hit != 'true'
-      run: curl -o micro.jar -L https://github.com/snowplow-incubator/snowplow-micro/releases/download/micro-1.3.3/snowplow-micro-1.3.3.jar
+      run: curl -o micro.jar -L https://github.com/snowplow-incubator/snowplow-micro/releases/download/micro-1.4.0/snowplow-micro-1.4.0.jar
 
     - name: Run Micro in background
       run: java -jar micro.jar --collector-config DemoApp/tests/micro/micro.conf --iglu DemoApp/tests/micro/iglu.json &

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+Version 1.4.0 (2022-02-04)
+--------------------------
+Add JavaScript tracker core to be used in Expo managed workflow when native trackers are not available (#188)
+Bump Snowplow native tracker dependency to 4.1 (#186)
+Update year in copyright headers to 2023 (#187)
+
 Version 1.3.0 (2022-10-03)
 --------------------------
 Upgrade Snowplow mobile trackers to v4 (#167)

--- a/DemoApp/ios/Podfile.lock
+++ b/DemoApp/ios/Podfile.lock
@@ -357,7 +357,7 @@ PODS:
   - RNSnowplowTracker (1.3.0):
     - React-Core
     - SnowplowTracker (~> 4.0)
-  - SnowplowTracker (4.0.0):
+  - SnowplowTracker (4.1.0):
     - FMDB (~> 2.7)
   - SocketRocket (0.6.0)
   - Yoga (1.14.0)
@@ -561,7 +561,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: c778439c3c430a5719d027d3c67423b390a221fe
   ReactCommon: ab1003b81be740fecd82509c370a45b1a7dda0c1
   RNSnowplowTracker: 4f395a9a7be502c486720f756ab6ee0d5cb33f6e
-  SnowplowTracker: 2ddc6db70af5415a87ac279f044d27d140b3a2b8
+  SnowplowTracker: 3f35a60dcb2cf9c4a56fa4cad46d5af6d1b5db44
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: c2b1f2494060865ac1f27e49639e72371b1205fa
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/DemoApp/ios/Podfile.lock
+++ b/DemoApp/ios/Podfile.lock
@@ -354,9 +354,9 @@ PODS:
     - React-jsi (= 0.69.5)
     - React-logger (= 0.69.5)
     - React-perflogger (= 0.69.5)
-  - RNSnowplowTracker (1.3.0):
+  - RNSnowplowTracker (1.4.0):
     - React-Core
-    - SnowplowTracker (~> 4.0)
+    - SnowplowTracker (~> 4.1)
   - SnowplowTracker (4.1.0):
     - FMDB (~> 2.7)
   - SocketRocket (0.6.0)
@@ -560,7 +560,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 42b34fde72e42446d9b08d2b9a3ddc2fa9ac6189
   React-runtimeexecutor: c778439c3c430a5719d027d3c67423b390a221fe
   ReactCommon: ab1003b81be740fecd82509c370a45b1a7dda0c1
-  RNSnowplowTracker: 4f395a9a7be502c486720f756ab6ee0d5cb33f6e
+  RNSnowplowTracker: b6a5a8514c515ff8bdff732ce7f239d46359d7a2
   SnowplowTracker: 3f35a60dcb2cf9c4a56fa4cad46d5af6d1b5db44
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: c2b1f2494060865ac1f27e49639e72371b1205fa

--- a/DemoApp/tests/e2e/emitEvents.e2e.detox.js
+++ b/DemoApp/tests/e2e/emitEvents.e2e.detox.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/DemoApp/tests/e2e/helpers/microCommands.js
+++ b/DemoApp/tests/e2e/helpers/microCommands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/DemoApp/tests/e2e/helpers/microHelpers.js
+++ b/DemoApp/tests/e2e/helpers/microHelpers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/DemoApp/tests/e2e/helpers/microHelpers.test.js
+++ b/DemoApp/tests/e2e/helpers/microHelpers.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/DemoApp/tests/e2e/helpers/schemas.js
+++ b/DemoApp/tests/e2e/helpers/schemas.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/DemoApp/tests/e2e/testEvents.micro.test.js
+++ b/DemoApp/tests/e2e/testEvents.micro.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/DemoApp/yarn.lock
+++ b/DemoApp/yarn.lock
@@ -1711,7 +1711,18 @@
     "@sinonjs/commons" "^1.7.0"
 
 "@snowplow/react-native-tracker@file:..":
-  version "1.3.0"
+  version "1.4.0"
+  dependencies:
+    "@snowplow/tracker-core" "3.8.0"
+    uuid "^3.4.0"
+
+"@snowplow/tracker-core@3.8.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@snowplow/tracker-core/-/tracker-core-3.8.0.tgz#bedcd84cdede8df4b8275f6031d57342e0d87769"
+  integrity sha512-fBQhHetV5c5s+Ea5bqaWrAcwG7C7Fdo0ztHKxvoVECwxMocWuTuiau0oM+dzkcjNyMoCa7bvX8BUNySvwwSrZA==
+  dependencies:
+    tslib "^2.3.1"
+    uuid "^3.4.0"
 
 "@types/babel__core@^7.1.14":
   version "7.1.18"
@@ -7183,6 +7194,11 @@ tslib@^2.0.1, tslib@^2.1.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
+tslib@^2.3.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+
 tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
@@ -7341,7 +7357,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.0.1:
+uuid@^3.0.1, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==

--- a/DemoAppTV/ios/Podfile.lock
+++ b/DemoAppTV/ios/Podfile.lock
@@ -249,9 +249,9 @@ PODS:
     - React-jsi (= 0.66.3-1)
     - React-logger (= 0.66.3-1)
     - React-perflogger (= 0.66.3-1)
-  - RNSnowplowTracker (1.3.0):
+  - RNSnowplowTracker (1.4.0):
     - React-Core
-    - SnowplowTracker (~> 4.0)
+    - SnowplowTracker (~> 4.1)
   - SnowplowTracker (4.1.0):
     - FMDB (~> 2.7)
   - Yoga (1.14.0)
@@ -387,7 +387,7 @@ SPEC CHECKSUMS:
   React-RCTText: 2d5191e551df3e74dbf27f71c2785081aaba4299
   React-runtimeexecutor: 04662d38a5b1fae4f8a0b5bf517946d0e7d6721a
   ReactCommon: 67042925ef6455377bb5edbc8d5c631a89dab901
-  RNSnowplowTracker: 4f395a9a7be502c486720f756ab6ee0d5cb33f6e
+  RNSnowplowTracker: b6a5a8514c515ff8bdff732ce7f239d46359d7a2
   SnowplowTracker: 3f35a60dcb2cf9c4a56fa4cad46d5af6d1b5db44
   Yoga: 56a884d4fa5c2f709125202018f44ea7b6e901a2
 

--- a/DemoAppTV/ios/Podfile.lock
+++ b/DemoAppTV/ios/Podfile.lock
@@ -252,7 +252,7 @@ PODS:
   - RNSnowplowTracker (1.3.0):
     - React-Core
     - SnowplowTracker (~> 4.0)
-  - SnowplowTracker (4.0.0):
+  - SnowplowTracker (4.1.0):
     - FMDB (~> 2.7)
   - Yoga (1.14.0)
 
@@ -388,7 +388,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 04662d38a5b1fae4f8a0b5bf517946d0e7d6721a
   ReactCommon: 67042925ef6455377bb5edbc8d5c631a89dab901
   RNSnowplowTracker: 4f395a9a7be502c486720f756ab6ee0d5cb33f6e
-  SnowplowTracker: 2ddc6db70af5415a87ac279f044d27d140b3a2b8
+  SnowplowTracker: 3f35a60dcb2cf9c4a56fa4cad46d5af6d1b5db44
   Yoga: 56a884d4fa5c2f709125202018f44ea7b6e901a2
 
 PODFILE CHECKSUM: 5492a106d2c554b63f3abd57277e2d2cce6fe1d3

--- a/DemoAppTV/yarn.lock
+++ b/DemoAppTV/yarn.lock
@@ -1464,7 +1464,18 @@
     "@sinonjs/commons" "^1.7.0"
 
 "@snowplow/react-native-tracker@file:..":
-  version "1.2.1"
+  version "1.4.0"
+  dependencies:
+    "@snowplow/tracker-core" "3.8.0"
+    uuid "^3.4.0"
+
+"@snowplow/tracker-core@3.8.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@snowplow/tracker-core/-/tracker-core-3.8.0.tgz#bedcd84cdede8df4b8275f6031d57342e0d87769"
+  integrity sha512-fBQhHetV5c5s+Ea5bqaWrAcwG7C7Fdo0ztHKxvoVECwxMocWuTuiau0oM+dzkcjNyMoCa7bvX8BUNySvwwSrZA==
+  dependencies:
+    tslib "^2.3.1"
+    uuid "^3.4.0"
 
 "@types/babel__core@^7.1.14":
   version "7.1.19"
@@ -6511,6 +6522,11 @@ tslib@^2.0.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
+tslib@^2.3.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+
 tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
@@ -6676,7 +6692,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^3.3.2:
+uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2020-2022 Snowplow Analytics Ltd, 2019 DataCamp.
+   Copyright (c) 2020-2023 Snowplow Analytics Ltd, 2019 DataCamp.
    All rights reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Feedback and contributions are welcome - if you have identified a bug, please lo
 
 ## Copyright and license
 
-The Snowplow React Native Tracker is copyright 2020-2022 Snowplow Analytics Ltd, 2019 DataCamp.
+The Snowplow React Native Tracker is copyright 2020-2023 Snowplow Analytics Ltd, 2019 DataCamp.
 
 Licensed under the **[Apache License, Version 2.0][license]** (the "License");
 you may not use this software except in compliance with the License.

--- a/RNSnowplowTracker.podspec
+++ b/RNSnowplowTracker.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency "SnowplowTracker", "~> 4.0"
+  s.dependency "SnowplowTracker", "~> 4.1"
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,5 +50,5 @@ dependencies {
     // Required Dependency for the Tracker
     implementation "com.squareup.okhttp3:okhttp:4.9.3"
     implementation "com.facebook.react:react-native:+"
-    implementation 'com.snowplowanalytics:snowplow-android-tracker:4.0.+'
+    implementation 'com.snowplowanalytics:snowplow-android-tracker:4.1.+'
 }

--- a/android/src/main/java/com/snowplowanalytics/react/util/TrackerVersion.java
+++ b/android/src/main/java/com/snowplowanalytics/react/util/TrackerVersion.java
@@ -2,6 +2,6 @@ package com.snowplowanalytics.react.util;
 
 public class TrackerVersion {
 
-    public final static String RN_TRACKER_VERSION = "rn-1.3.0";
+    public final static String RN_TRACKER_VERSION = "rn-1.4.0";
 
 }

--- a/ios/RNSnowplowTracker.h
+++ b/ios/RNSnowplowTracker.h
@@ -1,7 +1,7 @@
 //
 //  RNSnowplowTracker.h
 //
-//  Copyright (c) 2021-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2021-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,7 +14,7 @@
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
 //
-//  Copyright: Copyright (c) 2022 Snowplow Analytics Ltd
+//  Copyright: Copyright (c) 2023 Snowplow Analytics Ltd
 //  License: Apache License Version 2.0
 //
 

--- a/ios/RNSnowplowTracker.m
+++ b/ios/RNSnowplowTracker.m
@@ -1,7 +1,7 @@
 //
 //  RNSnowplowTracker.m
 //
-//  Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,7 +14,7 @@
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
 //
-//  Copyright: Copyright (c) 2022 Snowplow Analytics Ltd
+//  Copyright: Copyright (c) 2023 Snowplow Analytics Ltd
 //  License: Apache License Version 2.0
 //
 

--- a/ios/Util/NSDictionary+RNSP_TypeMethods.h
+++ b/ios/Util/NSDictionary+RNSP_TypeMethods.h
@@ -1,7 +1,7 @@
 //
 //  NSDictionary+RNSP_TypeMethods.h
 //
-//  Copyright (c) 2021-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2021-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,7 +14,7 @@
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
 //
-//  Copyright: Copyright (c) 2022 Snowplow Analytics Ltd
+//  Copyright: Copyright (c) 2023 Snowplow Analytics Ltd
 //  License: Apache License Version 2.0
 //
 

--- a/ios/Util/NSDictionary+RNSP_TypeMethods.m
+++ b/ios/Util/NSDictionary+RNSP_TypeMethods.m
@@ -1,7 +1,7 @@
 //
 //  NSDictionary+RNSP_TypeMethods.m
 //
-//  Copyright (c) 2021-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2021-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,7 +14,7 @@
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
 //
-//  Copyright: Copyright (c) 2022 Snowplow Analytics Ltd
+//  Copyright: Copyright (c) 2023 Snowplow Analytics Ltd
 //  License: Apache License Version 2.0
 //
 

--- a/ios/Util/RNConfigUtils.h
+++ b/ios/Util/RNConfigUtils.h
@@ -1,7 +1,7 @@
 //
 //  RNConfigUtils.h
 //
-//  Copyright (c) 2021-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2021-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,7 +14,7 @@
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
 //
-//  Copyright: Copyright (c) 2022 Snowplow Analytics Ltd
+//  Copyright: Copyright (c) 2023 Snowplow Analytics Ltd
 //  License: Apache License Version 2.0
 //
 

--- a/ios/Util/RNConfigUtils.m
+++ b/ios/Util/RNConfigUtils.m
@@ -1,7 +1,7 @@
 //
 //  RNConfigUtils.m
 //
-//  Copyright (c) 2021-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2021-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,7 +14,7 @@
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
 //
-//  Copyright: Copyright (c) 2022 Snowplow Analytics Ltd
+//  Copyright: Copyright (c) 2023 Snowplow Analytics Ltd
 //  License: Apache License Version 2.0
 //
 

--- a/ios/Util/RNTrackerVersion.h
+++ b/ios/Util/RNTrackerVersion.h
@@ -1,7 +1,7 @@
 //
 //  RNTrackerVersion.h
 //
-//  Copyright (c) 2021-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2021-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,7 +14,7 @@
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
 //
-//  Copyright: Copyright (c) 2022 Snowplow Analytics Ltd
+//  Copyright: Copyright (c) 2023 Snowplow Analytics Ltd
 //  License: Apache License Version 2.0
 //
 

--- a/ios/Util/RNTrackerVersion.m
+++ b/ios/Util/RNTrackerVersion.m
@@ -22,6 +22,6 @@
 
 @implementation RNTrackerVersion
 
-NSString * const kRNTrackerVersion = @"rn-1.3.0";
+NSString * const kRNTrackerVersion = @"rn-1.4.0";
 
 @end

--- a/ios/Util/RNTrackerVersion.m
+++ b/ios/Util/RNTrackerVersion.m
@@ -1,7 +1,7 @@
 //
 //  RNTrackerVersion.m
 //
-//  Copyright (c) 2021-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2021-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,7 +14,7 @@
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
 //
-//  Copyright: Copyright (c) 2022 Snowplow Analytics Ltd
+//  Copyright: Copyright (c) 2023 Snowplow Analytics Ltd
 //  License: Apache License Version 2.0
 //
 

--- a/ios/Util/RNUtilities.h
+++ b/ios/Util/RNUtilities.h
@@ -1,7 +1,7 @@
 //
 //  RNUtilities.h
 //
-//  Copyright (c) 2021-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2021-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,7 +14,7 @@
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
 //
-//  Copyright: Copyright (c) 2022 Snowplow Analytics Ltd
+//  Copyright: Copyright (c) 2023 Snowplow Analytics Ltd
 //  License: Apache License Version 2.0
 //
 

--- a/ios/Util/RNUtilities.m
+++ b/ios/Util/RNUtilities.m
@@ -1,7 +1,7 @@
 //
 //  RNUtilities.m
 //
-//  Copyright (c) 2021-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2021-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,7 +14,7 @@
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
 //
-//  Copyright: Copyright (c) 2022 Snowplow Analytics Ltd
+//  Copyright: Copyright (c) 2023 Snowplow Analytics Ltd
 //  License: Apache License Version 2.0
 //
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@snowplow/react-native-tracker",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@snowplow/react-native-tracker",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@snowplow/tracker-core": "3.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,15 @@
       "name": "@snowplow/react-native-tracker",
       "version": "1.3.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@snowplow/tracker-core": "3.8.0",
+        "uuid": "^3.4.0"
+      },
       "devDependencies": {
         "@types/jest": "^28.1.8",
         "@types/react": "^16.8.25",
         "@types/react-native": "^0.65.21",
+        "@types/uuid": "~3.4.6",
         "@typescript-eslint/eslint-plugin": "^5.13.0",
         "@typescript-eslint/parser": "^5.13.0",
         "eslint": "^8.23.1",
@@ -3878,6 +3883,20 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@snowplow/tracker-core": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@snowplow/tracker-core/-/tracker-core-3.8.0.tgz",
+      "integrity": "sha512-fBQhHetV5c5s+Ea5bqaWrAcwG7C7Fdo0ztHKxvoVECwxMocWuTuiau0oM+dzkcjNyMoCa7bvX8BUNySvwwSrZA==",
+      "dependencies": {
+        "tslib": "^2.3.1",
+        "uuid": "^3.4.0"
+      }
+    },
+    "node_modules/@snowplow/tracker-core/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
     "node_modules/@types/babel__core": {
       "version": "7.1.18",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.18.tgz",
@@ -4018,6 +4037,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.10.tgz",
+      "integrity": "sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -5434,9 +5459,9 @@
       }
     },
     "node_modules/decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "engines": {
         "node": ">=0.10"
       }
@@ -8928,9 +8953,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -12845,6 +12870,15 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
@@ -15910,6 +15944,22 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@snowplow/tracker-core": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@snowplow/tracker-core/-/tracker-core-3.8.0.tgz",
+      "integrity": "sha512-fBQhHetV5c5s+Ea5bqaWrAcwG7C7Fdo0ztHKxvoVECwxMocWuTuiau0oM+dzkcjNyMoCa7bvX8BUNySvwwSrZA==",
+      "requires": {
+        "tslib": "^2.3.1",
+        "uuid": "^3.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.18",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.18.tgz",
@@ -16050,6 +16100,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.10.tgz",
+      "integrity": "sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A==",
       "dev": true
     },
     "@types/yargs": {
@@ -17104,9 +17160,9 @@
       "peer": true
     },
     "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="
     },
     "dedent": {
       "version": "0.7.0",
@@ -19803,9 +19859,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -22934,6 +22990,11 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "peer": true
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-to-istanbul": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
     "type": "git",
     "url": "https://github.com/snowplow-incubator/snowplow-react-native-tracker"
   },
+  "dependencies": {
+    "@snowplow/tracker-core": "3.8.0",
+    "uuid": "^3.4.0"
+  },
   "peerDependencies": {
     "react": ">=16.8.6",
     "react-native": ">=0.65.0"
@@ -48,6 +52,7 @@
     "@types/react-native": "^0.65.21",
     "@typescript-eslint/eslint-plugin": "^5.13.0",
     "@typescript-eslint/parser": "^5.13.0",
+    "@types/uuid": "~3.4.6",
     "eslint": "^8.23.1",
     "eslint-plugin-jest": "^27.0.4",
     "eslint-plugin-promise": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowplow/react-native-tracker",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A library for tracking Snowplow events in React Native",
   "homepage": "https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/react-native-tracker/",
   "main": "dist/index.js",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/configurations.ts
+++ b/src/configurations.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -75,6 +75,16 @@ const logMessages = {
   setSubjectData: 'setSubjectData:',
 };
 
+const schemas = {
+  payloadData:
+    'iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-4',
+  timingSchema: 'iglu:com.snowplowanalytics.snowplow/timing/jsonschema/1-0-0',
+  deepLinkReceivedSchema: 'iglu:com.snowplowanalytics.mobile/deep_link_received/jsonschema/1-0-0',
+  messageNotificationSchema: 'iglu:com.snowplowanalytics.mobile/message_notification/jsonschema/1-0-0',
+  screenViewSchema: 'iglu:com.snowplowanalytics.mobile/screen_view/jsonschema/1-0-0',
+};
+
 export {
   logMessages,
+  schemas,
 };

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/jsCore.ts
+++ b/src/jsCore.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/jsCore.ts
+++ b/src/jsCore.ts
@@ -48,7 +48,7 @@ import { schemas } from './constants';
 import { v4 as uuid } from 'uuid';
 
 // Tracker version added to the events
-const trackerVersion = 'rn-1.3.0';
+const trackerVersion = 'rn-1.4.0';
 
 interface Tracker extends TrackerCore {
   setDomainUserId: (duid: string | undefined) => void;

--- a/src/jsCore.ts
+++ b/src/jsCore.ts
@@ -1,0 +1,531 @@
+/*
+ * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+'use strict';
+
+import type {
+  InitTrackerConfiguration,
+  SelfDescribing,
+  EventContext,
+  StructuredProps,
+  ScreenViewProps,
+  ScreenSize,
+  PageViewProps,
+  TimingProps,
+  ConsentGrantedProps,
+  ConsentWithdrawnProps,
+  EcommerceTransactionProps,
+  DeepLinkReceivedProps,
+  MessageNotificationProps,
+  NetworkConfiguration,
+} from './types';
+
+import {
+  Payload,
+  trackerCore,
+  PayloadBuilder,
+  buildSelfDescribingEvent,
+  buildStructEvent,
+  buildPageView,
+  buildConsentGranted,
+  buildConsentWithdrawn,
+  buildEcommerceTransaction,
+  buildEcommerceTransactionItem,
+} from '@snowplow/tracker-core';
+import type { TrackerCore } from '@snowplow/tracker-core';
+import { errorHandler } from './utils';
+import { schemas } from './constants';
+import { v4 as uuid } from 'uuid';
+
+// Tracker version added to the events
+const trackerVersion = 'rn-1.3.0';
+
+interface Tracker extends TrackerCore {
+  setDomainUserId: (duid: string | undefined) => void;
+  setNetworkUserId: (nuid: string | undefined) => void;
+}
+
+let trackers: { [namespace: string]: Tracker } = {};
+
+function preparePayload(payload: Payload): Record<string, string> {
+  const stringifiedPayload: Record<string, string> = {};
+
+  payload['stm'] = new Date().getTime().toString();
+
+  for (const key in payload) {
+    if (Object.prototype.hasOwnProperty.call(payload, key)) {
+      stringifiedPayload[key] = String(payload[key]);
+    }
+  }
+  return stringifiedPayload;
+}
+
+function createEmitCallback(networkConfig: NetworkConfiguration): (e: Payload) => void {
+  return (e: Payload) => {
+    const postJson = {
+      schema: schemas.payloadData,
+      data: [preparePayload(e)],
+    };
+    const endpoint = networkConfig.endpoint;
+    const postPath =
+      networkConfig.customPostPath ?? '/com.snowplowanalytics.snowplow/tp2';
+    const headers = networkConfig.requestHeaders ?? {};
+    fetch(endpoint + postPath, {
+      method: 'POST',
+      body: JSON.stringify(postJson),
+      headers: {
+        'Content-Type': 'application/json',
+        ...headers,
+      },
+    }).catch(errorHandler);
+  };
+}
+
+function updateTrackerProperties(tracker: Tracker, configuration: InitTrackerConfiguration): void {
+  tracker.setPlatform(configuration.trackerConfig?.devicePlatform ?? 'mob');
+  tracker.setTrackerVersion(trackerVersion);
+  tracker.setTrackerNamespace(configuration.namespace);
+  if (configuration.trackerConfig?.appId != null) {
+    tracker.setAppId(configuration.trackerConfig.appId);
+  }
+  if (configuration.subjectConfig?.colorDepth != null) {
+    tracker.setColorDepth(String(configuration.subjectConfig.colorDepth));
+  }
+  if (configuration.subjectConfig?.domainUserId != null) {
+    tracker.setDomainUserId(configuration.subjectConfig.domainUserId);
+  }
+  if (configuration.subjectConfig?.ipAddress != null) {
+    tracker.setIpAddress(configuration.subjectConfig.ipAddress);
+  }
+  if (configuration.subjectConfig?.language != null) {
+    tracker.setLang(configuration.subjectConfig.language);
+  }
+  if (configuration.subjectConfig?.screenResolution != null) {
+    tracker.setScreenResolution(
+      String(configuration.subjectConfig.screenResolution[0]),
+      String(configuration.subjectConfig.screenResolution[1])
+    );
+  }
+  if (configuration.subjectConfig?.screenViewport != null) {
+    tracker.setViewport(
+      String(configuration.subjectConfig.screenViewport[0]),
+      String(configuration.subjectConfig.screenViewport[1])
+    );
+  }
+  if (configuration.subjectConfig?.timezone != null) {
+    tracker.setTimezone(configuration.subjectConfig.timezone);
+  }
+  if (configuration.subjectConfig?.userId != null) {
+    tracker.setUserId(configuration.subjectConfig.userId);
+  }
+  if (configuration.subjectConfig?.useragent != null) {
+    tracker.setUseragent(configuration.subjectConfig.useragent);
+  }
+}
+
+function createTracker(
+  configuration: InitTrackerConfiguration,
+  emitCallback?: (e: Payload) => void
+): Promise<void> {
+  // create an emit callback if not given
+  const emitter = emitCallback ?? createEmitCallback(configuration.networkConfig);
+
+  // the tracker core does not provide an option to set the duid, so we need to add custom
+  let domainUserId: string | undefined;
+  const setDomainUserId = (userId: string | undefined): void => {
+    domainUserId = userId;
+  };
+  let networkUserId: string | undefined;
+  const setNetworkUserId = (userId: string | undefined): void => {
+    networkUserId = userId;
+  };
+
+  // initialize the tracker core
+  const core = trackerCore({
+    base64: configuration.trackerConfig?.base64Encoding ?? true,
+    callback: (payload: PayloadBuilder) => {
+      if (domainUserId != null) {
+        payload.add('duid', domainUserId);
+      }
+      if (networkUserId != null) {
+        payload.add('tnuid', networkUserId);
+      }
+      const builtPayload = payload.build();
+      emitter(builtPayload);
+    },
+  });
+  const tracker = { ...core, setDomainUserId, setNetworkUserId };
+  trackers[configuration.namespace] = tracker;
+
+  // update tracker properties to reflect subject and tracker info
+  updateTrackerProperties(tracker, configuration);
+
+  return <Promise<void>>Promise.resolve();
+}
+
+function removeTracker(details: { tracker: string }): Promise<boolean> {
+  delete trackers[details.tracker];
+  return <Promise<boolean>>Promise.resolve(true);
+}
+
+function removeAllTrackers(): Promise<boolean> {
+  trackers = {};
+  return <Promise<boolean>>Promise.resolve(true);
+}
+
+function forTracker(
+  namespace: string | null,
+  callback: (tracker: Tracker) => void
+): void {
+  const tracker = namespace != null ? trackers[namespace] : Object.values(trackers)[0];
+
+  if (tracker) {
+    callback(tracker);
+  } else {
+    errorHandler(new Error('No such tracker found.'));
+  }
+}
+
+function trackSelfDescribingEvent(details: {
+  tracker: string | null;
+  eventData: SelfDescribing;
+  contexts: EventContext[];
+}): Promise<void> {
+  forTracker(details.tracker, (tracker) => {
+    tracker.track(
+      buildSelfDescribingEvent({
+        event: details.eventData,
+      }),
+      details.contexts
+    );
+  });
+  return <Promise<void>>Promise.resolve();
+}
+
+function trackStructuredEvent(details: {
+  tracker: string | null;
+  eventData: StructuredProps;
+  contexts: EventContext[];
+}): Promise<void> {
+  forTracker(details.tracker, (tracker) => {
+    tracker.track(buildStructEvent(details.eventData), details.contexts);
+  });
+  return <Promise<void>>Promise.resolve();
+}
+
+function trackScreenViewEvent(details: {
+  tracker: string | null;
+  eventData: ScreenViewProps;
+  contexts: EventContext[];
+}): Promise<void> {
+  const data: ScreenViewProps = {
+    name: details.eventData.name,
+    id: details.eventData.id ?? uuid()
+  };
+  if (details.eventData.type != null) {
+    data.type = details.eventData.type;
+  }
+  if (details.eventData.previousName != null) {
+    data.previousName = details.eventData.previousName;
+  }
+  if (details.eventData.previousId != null) {
+    data.previousId = details.eventData.previousId;
+  }
+  if (details.eventData.previousType != null) {
+    data.previousType = details.eventData.previousType;
+  }
+  if (details.eventData.transitionType != null) {
+    data.transitionType = details.eventData.transitionType;
+  }
+
+  return trackSelfDescribingEvent({
+    tracker: details.tracker,
+    eventData: {
+      schema: schemas.screenViewSchema,
+      data: data
+    },
+    contexts: details.contexts,
+  });
+}
+
+function trackPageViewEvent(details: {
+  tracker: string | null;
+  eventData: PageViewProps;
+  contexts: EventContext[];
+}): Promise<void> {
+  forTracker(details.tracker, (tracker) => {
+    tracker.track(buildPageView(details.eventData), details.contexts);
+  });
+  return <Promise<void>>Promise.resolve();
+}
+
+function trackTimingEvent(details: {
+  tracker: string | null;
+  eventData: TimingProps;
+  contexts: EventContext[];
+}): Promise<void> {
+  return trackSelfDescribingEvent({
+    tracker: details.tracker,
+    eventData: {
+      schema: schemas.timingSchema,
+      data: details.eventData,
+    },
+    contexts: details.contexts,
+  });
+}
+
+function trackConsentGrantedEvent(details: {
+  tracker: string | null;
+  eventData: ConsentGrantedProps;
+  contexts: EventContext[];
+}): Promise<void> {
+  forTracker(details.tracker, (tracker) => {
+    const built = buildConsentGranted({
+      id: details.eventData.documentId,
+      version: details.eventData.version,
+      name: details.eventData.name,
+      description: details.eventData.documentDescription,
+      expiry: details.eventData.expiry,
+    });
+    tracker.track(built.event, details.contexts.concat(built.context));
+  });
+  return <Promise<void>>Promise.resolve();
+}
+
+function trackConsentWithdrawnEvent(details: {
+  tracker: string | null;
+  eventData: ConsentWithdrawnProps;
+  contexts: EventContext[];
+}): Promise<void> {
+  forTracker(details.tracker, (tracker) => {
+    const built = buildConsentWithdrawn({
+      all: details.eventData.all,
+      id: details.eventData.documentId,
+      version: details.eventData.version,
+      name: details.eventData.name,
+      description: details.eventData.documentDescription,
+    });
+    tracker.track(built.event, details.contexts.concat(built.context));
+  });
+  return <Promise<void>>Promise.resolve();
+}
+
+function trackEcommerceTransactionEvent(details: {
+  tracker: string | null;
+  eventData: EcommerceTransactionProps;
+  contexts: EventContext[];
+}): Promise<void> {
+  forTracker(details.tracker, (tracker) => {
+    details.eventData.items.forEach(item => {
+      tracker.track(
+        buildEcommerceTransactionItem({
+          ...item,
+          orderId: details.eventData.orderId
+        }),
+        details.contexts
+      );
+    });
+    tracker.track(
+      buildEcommerceTransaction({
+        orderId: details.eventData.orderId,
+        total: details.eventData.totalValue,
+        affiliation: details.eventData.affiliation,
+        tax: details.eventData.taxValue,
+        shipping: details.eventData.shipping,
+        city: details.eventData.city,
+        state: details.eventData.state,
+        country: details.eventData.country,
+        currency: details.eventData.currency,
+      }),
+      details.contexts
+    );
+  });
+  return <Promise<void>>Promise.resolve();
+}
+
+function trackDeepLinkReceivedEvent(details: {
+  tracker: string | null;
+  eventData: DeepLinkReceivedProps;
+  contexts: EventContext[];
+}): Promise<void> {
+  return trackSelfDescribingEvent({
+    tracker: details.tracker,
+    eventData: {
+      schema: schemas.deepLinkReceivedSchema,
+      data: details.eventData,
+    },
+    contexts: details.contexts,
+  });
+}
+
+function trackMessageNotificationEvent(details: {
+  tracker: string | null;
+  eventData: MessageNotificationProps;
+  contexts: EventContext[];
+}): Promise<void> {
+  return trackSelfDescribingEvent({
+    tracker: details.tracker,
+    eventData: {
+      schema: schemas.messageNotificationSchema,
+      data: details.eventData,
+    },
+    contexts: details.contexts,
+  });
+}
+
+function removeGlobalContexts(): Promise<void> {
+  return <Promise<void>>Promise.reject(new Error('Not implemented'));
+}
+
+function addGlobalContexts(): Promise<void> {
+  return <Promise<void>>Promise.reject(new Error('Not implemented'));
+}
+
+function setUserId(details: { tracker: string; userId: string | null }): Promise<void> {
+  trackers[details.tracker]?.setUserId(details.userId ?? '');
+  return <Promise<void>>Promise.resolve();
+}
+
+function setNetworkUserId(details: {
+  tracker: string;
+  networkUserId: string | null;
+}): Promise<void> {
+  trackers[details.tracker]?.setNetworkUserId(details.networkUserId ?? '');
+  return <Promise<void>>Promise.resolve();
+}
+
+function setDomainUserId(details: {
+  tracker: string;
+  domainUserId: string | null;
+}): Promise<void> {
+  trackers[details.tracker]?.setDomainUserId(details.domainUserId ?? '');
+  return <Promise<void>>Promise.resolve();
+}
+
+function setIpAddress(details: { tracker: string; ipAddress: string | null }): Promise<void> {
+  trackers[details.tracker]?.setIpAddress(details.ipAddress ?? '');
+  return <Promise<void>>Promise.resolve();
+}
+
+function setUseragent(details: { tracker: string; useragent: string | null }): Promise<void> {
+  trackers[details.tracker]?.setUseragent(details.useragent ?? '');
+  return <Promise<void>>Promise.resolve();
+}
+
+function setTimezone(details: { tracker: string; timezone: string | null }): Promise<void> {
+  trackers[details.tracker]?.setTimezone(details.timezone ?? '');
+  return <Promise<void>>Promise.resolve();
+}
+
+function setLanguage(details: { tracker: string; language: string | null }): Promise<void> {
+  trackers[details.tracker]?.setLang(details.language ?? '');
+  return <Promise<void>>Promise.resolve();
+}
+
+function setScreenResolution(details: {
+  tracker: string;
+  screenResolution: ScreenSize | null;
+}): Promise<void> {
+  if (details.screenResolution) {
+    trackers[details.tracker]?.setScreenResolution(
+      String(details.screenResolution[0]),
+      String(details.screenResolution[1])
+    );
+  } else {
+    trackers[details.tracker]?.addPayloadPair('res', '');
+  }
+  return <Promise<void>>Promise.resolve();
+}
+
+function setScreenViewport(details: {
+  tracker: string;
+  screenViewport: ScreenSize | null;
+}): Promise<void> {
+  if (details.screenViewport) {
+    trackers[details.tracker]?.setViewport(
+      String(details.screenViewport[0]),
+      String(details.screenViewport[1])
+    );
+  } else {
+    trackers[details.tracker]?.addPayloadPair('vp', '');
+  }
+  return <Promise<void>>Promise.resolve();
+}
+
+function setColorDepth(details: {
+  tracker: string;
+  colorDepth: number | null;
+}): Promise<void> {
+  trackers[details.tracker]?.setColorDepth(String(details.colorDepth ?? ''));
+  return <Promise<void>>Promise.resolve();
+}
+
+function getSessionUserId(): Promise<string> {
+  return <Promise<string>>Promise.reject(new Error('Not implemented'));
+}
+
+function getSessionId(): Promise<string> {
+  return <Promise<string>>Promise.reject(new Error('Not implemented'));
+}
+
+function getSessionIndex(): Promise<number> {
+  return <Promise<number>>Promise.reject(new Error('Not implemented'));
+}
+
+function getIsInBackground(): Promise<boolean> {
+  return <Promise<boolean>>Promise.reject(new Error('Not implemented'));
+}
+
+function getBackgroundIndex(): Promise<number> {
+  return <Promise<number>>Promise.reject(new Error('Not implemented'));
+}
+
+function getForegroundIndex(): Promise<number> {
+  return <Promise<number>>Promise.reject(new Error('Not implemented'));
+}
+
+const JSSnowplowTracker = Object.freeze({
+  createTracker,
+  removeTracker,
+  removeAllTrackers,
+  trackSelfDescribingEvent,
+  trackStructuredEvent,
+  trackScreenViewEvent,
+  trackPageViewEvent,
+  trackTimingEvent,
+  trackConsentGrantedEvent,
+  trackConsentWithdrawnEvent,
+  trackEcommerceTransactionEvent,
+  trackDeepLinkReceivedEvent,
+  trackMessageNotificationEvent,
+  removeGlobalContexts,
+  addGlobalContexts,
+  setUserId,
+  setNetworkUserId,
+  setDomainUserId,
+  setIpAddress,
+  setUseragent,
+  setTimezone,
+  setLanguage,
+  setScreenResolution,
+  setScreenViewport,
+  setColorDepth,
+  getSessionUserId,
+  getSessionId,
+  getSessionIndex,
+  getIsInBackground,
+  getBackgroundIndex,
+  getForegroundIndex,
+});
+
+export { JSSnowplowTracker };

--- a/src/native.ts
+++ b/src/native.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/native.ts
+++ b/src/native.ts
@@ -14,8 +14,20 @@
 'use strict';
 
 import { NativeModules } from 'react-native';
+import { JSSnowplowTracker } from './jsCore';
+import type { Native } from './types';
+import { errorHandler } from './utils';
 
-const { RNSnowplowTracker } = NativeModules;
+const isAvailable = NativeModules.RNSnowplowTracker != null;
+if (!isAvailable) {
+  errorHandler(
+    new Error(
+      'Unable to access the native iOS/Android Snowplow tracker, a tracker implementation with very limited functionality is used.'
+    )
+  );
+}
+
+const RNSnowplowTracker: Native = isAvailable ? NativeModules.RNSnowplowTracker as Native : JSSnowplowTracker;
 
 export {
   RNSnowplowTracker

--- a/src/subject.ts
+++ b/src/subject.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/types.ts
+++ b/src/types.ts
@@ -948,3 +948,128 @@ export type WebViewMessage = {
   context?: Array<SelfDescribing> | null;
   trackers?: Array<string>;
 };
+
+/**
+ * Internal type for representing the interface to the native trackers.
+ */
+export interface Native {
+  createTracker: (configuration: InitTrackerConfiguration) => Promise<void>;
+  removeTracker: (details: { tracker: string }) => Promise<boolean>;
+  removeAllTrackers: () => Promise<boolean>;
+  trackSelfDescribingEvent: (details: {
+    tracker: string | null;
+    eventData: SelfDescribing;
+    contexts: EventContext[];
+  }) => Promise<void>;
+  trackStructuredEvent: (details: {
+    tracker: string | null;
+    eventData: StructuredProps;
+    contexts: EventContext[];
+  }) => Promise<void>;
+  trackScreenViewEvent: (details: {
+    tracker: string | null;
+    eventData: ScreenViewProps;
+    contexts: EventContext[];
+  }) => Promise<void>;
+  trackPageViewEvent: (details: {
+    tracker: string | null;
+    eventData: PageViewProps;
+    contexts: EventContext[];
+  }) => Promise<void>;
+  trackTimingEvent: (details: {
+    tracker: string | null;
+    eventData: TimingProps;
+    contexts: EventContext[];
+  }) => Promise<void>;
+  trackConsentGrantedEvent: (details: {
+    tracker: string | null;
+    eventData: ConsentGrantedProps;
+    contexts: EventContext[];
+  }) => Promise<void>;
+  trackConsentWithdrawnEvent: (details: {
+    tracker: string | null;
+    eventData: ConsentWithdrawnProps;
+    contexts: EventContext[];
+  }) => Promise<void>;
+  trackEcommerceTransactionEvent: (details: {
+    tracker: string | null;
+    eventData: EcommerceTransactionProps;
+    contexts: EventContext[];
+  }) => Promise<void>;
+  trackDeepLinkReceivedEvent: (details: {
+    tracker: string | null;
+    eventData: DeepLinkReceivedProps;
+    contexts: EventContext[];
+  }) => Promise<void>;
+  trackMessageNotificationEvent: (details: {
+    tracker: string | null;
+    eventData: MessageNotificationProps;
+    contexts: EventContext[];
+  }) => Promise<void>;
+  removeGlobalContexts: (details: {
+    tracker: string;
+    removeTag: string;
+  }) => Promise<void>;
+  addGlobalContexts: (details: {
+    tracker: string;
+    addGlobalContext: GlobalContext;
+  }) => Promise<void>;
+  setUserId: (details: {
+    tracker: string;
+    userId: string | null;
+  }) => Promise<void>;
+  setNetworkUserId: (details: {
+    tracker: string;
+    networkUserId: string | null;
+  }) => Promise<void>;
+  setDomainUserId: (details: {
+    tracker: string;
+    domainUserId: string | null;
+  }) => Promise<void>;
+  setIpAddress: (details: {
+    tracker: string;
+    ipAddress: string | null;
+  }) => Promise<void>;
+  setUseragent: (details: {
+    tracker: string;
+    useragent: string | null;
+  }) => Promise<void>;
+  setTimezone: (details: {
+    tracker: string;
+    timezone: string | null;
+  }) => Promise<void>;
+  setLanguage: (details: {
+    tracker: string;
+    language: string | null;
+  }) => Promise<void>;
+  setScreenResolution: (details: {
+    tracker: string;
+    screenResolution: ScreenSize | null;
+  }) => Promise<void>;
+  setScreenViewport: (details: {
+    tracker: string;
+    screenViewport: ScreenSize | null;
+  }) => Promise<void>;
+  setColorDepth: (details: {
+    tracker: string;
+    colorDepth: number | null;
+  }) => Promise<void>;
+  getSessionUserId: (details: {
+    tracker: string;
+  }) => Promise<string>;
+  getSessionId: (details: {
+    tracker: string;
+  }) => Promise<string>;
+  getSessionIndex: (details: {
+    tracker: string;
+  }) => Promise<number>;
+  getIsInBackground: (details: {
+    tracker: string;
+  }) => Promise<boolean>;
+  getBackgroundIndex: (details: {
+    tracker: string;
+  }) => Promise<number>;
+  getForegroundIndex: (details: {
+    tracker: string;
+  }) => Promise<number>;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/webViewInterface.ts
+++ b/src/webViewInterface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/tests/__tests__/api.test.ts
+++ b/tests/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/tests/__tests__/configurations.test.ts
+++ b/tests/__tests__/configurations.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/tests/__tests__/events.test.ts
+++ b/tests/__tests__/events.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/tests/__tests__/index.test.ts
+++ b/tests/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/tests/__tests__/jsCore.test.ts
+++ b/tests/__tests__/jsCore.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/tests/__tests__/jsCore.test.ts
+++ b/tests/__tests__/jsCore.test.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+import type { Payload } from '@snowplow/tracker-core';
+import type { InitTrackerConfiguration } from '../../src/types';
+import { JSSnowplowTracker } from '../../src/jsCore';
+
+async function createTracker(
+  configuration: InitTrackerConfiguration,
+  callback?: () => Promise<void>
+): Promise<Payload[]> {
+  if (configuration.trackerConfig) {
+    configuration.trackerConfig.base64Encoding = false;
+  } else {
+    configuration.trackerConfig = { base64Encoding: false };
+  }
+
+  const trackedPayloads: Payload[] = [];
+  const emitter = (payload: Payload): void => {
+    trackedPayloads.push(payload);
+  };
+  await JSSnowplowTracker.createTracker(configuration, emitter);
+  if (callback) {
+    await callback();
+  }
+
+  return trackedPayloads;
+}
+describe('test jsCore', () => {
+  beforeEach(async () => {
+    await JSSnowplowTracker.removeAllTrackers();
+  });
+
+  test('sets Subject properties and tracks structured event', async () => {
+    const trackedPayloads = await createTracker(
+      {
+        namespace: 'ns',
+        networkConfig: { endpoint: 'http://localhost' },
+        subjectConfig: {
+          userId: 'user1',
+        },
+      },
+      async () => {
+        await JSSnowplowTracker.trackStructuredEvent({
+          tracker: 'ns',
+          eventData: { category: 'cat', action: 'act' },
+          contexts: [],
+        });
+      }
+    );
+
+    expect(trackedPayloads.length).toBe(1);
+    expect(trackedPayloads[0]?.uid).toEqual('user1');
+    expect(trackedPayloads[0]?.se_ca).toEqual('cat');
+    expect(trackedPayloads[0]?.se_ac).toEqual('act');
+  });
+
+  test('tracks screen view event with default tracker', async () => {
+    const trackedPayloads = await createTracker(
+      {
+        namespace: 'ns',
+        networkConfig: { endpoint: 'http://localhost' },
+      },
+      async () => {
+        await JSSnowplowTracker.trackScreenViewEvent({
+          tracker: null,
+          eventData: { id: 'id1', name: 'screen' },
+          contexts: [],
+        });
+      }
+    );
+
+    expect(trackedPayloads.length).toBe(1);
+    expect(trackedPayloads[0]?.tna).toEqual('ns');
+    expect(trackedPayloads[0]?.ue_pr ?? '').toContain('"name":"screen"');
+  });
+
+  test('works with multiple trackers', async () => {
+    const tracker1Payloads = await createTracker(
+      {
+        namespace: 'ns1',
+        networkConfig: { endpoint: 'e1' },
+      }
+    );
+    expect(tracker1Payloads.length).toBe(0);
+
+    const tracker2Payloads = await createTracker(
+      {
+        namespace: 'ns2',
+        networkConfig: { endpoint: 'e2' },
+      },
+      async () => {
+        // track with default tracker
+        await JSSnowplowTracker.trackPageViewEvent({
+          tracker: null,
+          eventData: { pageUrl: 'p1' },
+          contexts: [],
+        });
+        // track with tracker 2
+        await JSSnowplowTracker.trackPageViewEvent({
+          tracker: 'ns2',
+          eventData: { pageUrl: 'p2' },
+          contexts: [],
+        });
+        // track with tracker 1
+        await JSSnowplowTracker.trackPageViewEvent({
+          tracker: 'ns1',
+          eventData: { pageUrl: 'p3' },
+          contexts: [],
+        });
+      }
+    );
+
+    expect(tracker1Payloads.length).toBe(2);
+    expect(tracker2Payloads.length).toBe(1);
+    expect(tracker2Payloads[0]?.url).toEqual('p2');
+  });
+
+  test('set user ID for initialized tracker', async () => {
+    const payloads = await createTracker({
+      namespace: 'ns1',
+      networkConfig: { endpoint: 'e' },
+      subjectConfig: { userId: 'shouldChange' },
+    });
+    await JSSnowplowTracker.setUserId({ tracker: 'ns1', userId: 'theUser' });
+    await JSSnowplowTracker.trackDeepLinkReceivedEvent({
+      tracker: 'ns1',
+      eventData: { url: 'https://apple.com' },
+      contexts: [],
+    });
+
+    expect(payloads.length).toBe(1);
+    expect(payloads[0]?.uid).toEqual('theUser');
+  });
+
+  test('adds context entities to events', async () => {
+    const payloads = await createTracker(
+      { namespace: 'ns1', networkConfig: { endpoint: 'e' } },
+      async () => {
+        await JSSnowplowTracker.trackEcommerceTransactionEvent({
+          tracker: null,
+          eventData: {
+            orderId: 'o1',
+            totalValue: 10,
+            items: [],
+          },
+          contexts: [
+            {
+              schema:
+                'iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1',
+              data: { targetUrl: 'http://a-target-url.com' },
+            },
+          ],
+        });
+      }
+    );
+
+    expect(payloads.length).toBe(1);
+    expect(payloads[0]?.co).toContain('"targetUrl":"http://a-target-url.com"');
+  });
+});

--- a/tests/__tests__/utils.test.ts
+++ b/tests/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.


### PR DESCRIPTION
This release brings support for the Expo Go and managed workflow. In this setup, the tracker is not able to access the underlying native mobile trackers. To work around this limitation, the React Native tracker now also includes a JavaScript-only tracker to be used in this scenario.

The JavaScript-only implementation is more limited than the setup with native trackers. It provides basic functionality to manually track events with context entities and subject properties. However, it doesn't yet have support for session tracking, various auto-tracking features in the React Native tracker and advanced emitter features such as batching and retries. Nevertheless, it opens the door for tracking Snowplow events in Expo Go and we are happy to receive feedback and improve the implementation in the future!

The release also updates the underlying native trackers to version 4.1 which brings improvements in anonymous tracking and tracking deep links, [see here](https://discourse.snowplow.io/t/snowplow-android-and-ios-trackers-version-4-1/7751).

**Enhancements**

* Add JavaScript tracker core to be used in Expo managed workflow when native trackers are not available (#188)

**Under the hood**

* Bump Snowplow native tracker dependency to 4.1 (#186)
* Update year in copyright headers to 2023 (#187)