### PR TITLE
Fix crash on iOS on React Native new architecture (close #212)

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Upload events artifact if Detox-Jest failed
         if: ${{ failure() && steps.dj.outcome == 'failure' && steps.eventlog.outcome == 'success' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: android-events-artifact
           path: android-events-micro.json

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Upload events artifact if Detox-Jest failed
         if: ${{ failure() && steps.dj.outcome == 'failure' && steps.eventlog.outcome == 'success' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ios-events-artifact
           path: ios-events-micro.json

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -668,9 +668,9 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 57d2868c099736d80fcd648bf211b4431e51a558
+  boost: 7dcd2de282d72e344012f7d6564d024930a6a440
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
+  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   FBLazyVector: 25cbffbaec517695d376ab4bc428948cd0f08088
   FBReactNativeSpec: e03b22fbf7017a6f76641ea4472e73c915dcdda7
   Flipper: 6edb735e6c3e332975d1b17956bcc584eccf5818
@@ -682,7 +682,7 @@ SPEC CHECKSUMS:
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   FlipperKit: 2efad7007d6745a3f95e4034d547be637f89d3f6
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 5b340c6a5affbf3aba22185be41563bbb2426654
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c

--- a/ios/ReactNativeTracker.mm
+++ b/ios/ReactNativeTracker.mm
@@ -2,10 +2,6 @@
 
 @interface RCT_EXTERN_MODULE(ReactNativeTracker, NSObject)
 
-RCT_EXTERN_METHOD(multiply:(float)a withB:(float)b
-                 withResolver:(RCTPromiseResolveBlock)resolve
-                 withRejecter:(RCTPromiseRejectBlock)reject)
-
 RCT_EXTERN_METHOD(createTracker:
                   (NSDictionary *)argmap
                   resolver:(RCTPromiseResolveBlock)resolve


### PR DESCRIPTION
Issue #212 

The culprit why the tracker crashed on iOS under the RN new architecture was [this extra ObjC function](https://github.com/snowplow/snowplow-react-native-tracker/pull/213/files#diff-d942ab96abb752524b9bf52f3ede887e6f8a0b4bdd8088ddf87bc170e185c0bdL5) in the code – it shouldn't have been there and was missing implementation. So the fix was just removing that function.

I have tested this separately in a React Native app with new architecture enabled. I wanted to also add the new architecture to CI but that will require a separate PR since it completely breaks the e2e and build actions 😅 