### PR TITLE
Release/2.1.2

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Upload events artifact if Detox-Jest failed
         if: ${{ failure() && steps.dj.outcome == 'failure' && steps.eventlog.outcome == 'success' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: android-events-artifact
           path: android-events-micro.json

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Upload events artifact if Detox-Jest failed
         if: ${{ failure() && steps.dj.outcome == 'failure' && steps.eventlog.outcome == 'success' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ios-events-artifact
           path: ios-events-micro.json

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 2.1.2 (2024-10-31)
+--------------------------
+Fix crash on iOS on React Native new architecture (#212)
+
 Version 2.1.1 (2024-07-03)
 --------------------------
 Update tracker and example app dependencies

--- a/android/src/main/java/com/snowplow/reactnativetracker/util/TrackerVersion.kt
+++ b/android/src/main/java/com/snowplow/reactnativetracker/util/TrackerVersion.kt
@@ -1,5 +1,5 @@
 package com.snowplow.reactnativetracker.util
 
 object TrackerVersion {
-  const val RN_TRACKER_VERSION = "rn-2.1.1"
+  const val RN_TRACKER_VERSION = "rn-2.1.2"
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -668,9 +668,9 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 57d2868c099736d80fcd648bf211b4431e51a558
+  boost: 7dcd2de282d72e344012f7d6564d024930a6a440
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
+  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   FBLazyVector: 25cbffbaec517695d376ab4bc428948cd0f08088
   FBReactNativeSpec: e03b22fbf7017a6f76641ea4472e73c915dcdda7
   Flipper: 6edb735e6c3e332975d1b17956bcc584eccf5818
@@ -682,7 +682,7 @@ SPEC CHECKSUMS:
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   FlipperKit: 2efad7007d6745a3f95e4034d547be637f89d3f6
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 5b340c6a5affbf3aba22185be41563bbb2426654
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -488,7 +488,7 @@ PODS:
     - React-jsi (= 0.72.15)
     - React-logger (= 0.72.15)
     - React-perflogger (= 0.72.15)
-  - snowplow-react-native-tracker (2.1.1):
+  - snowplow-react-native-tracker (2.1.2):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
     - SnowplowTracker (~> 6.0)
@@ -719,7 +719,7 @@ SPEC CHECKSUMS:
   React-runtimescheduler: ae08ede2e0267be2a4d8ba82a54d5908949d5a34
   React-utils: 8eb3c12fd4a4da6df3824f7d9a961d73a6ed6e5d
   ReactCommon: d2de36ed3eebe700d7169b9e80f7d1a4b98e178d
-  snowplow-react-native-tracker: d947a5d147cb5e401f0c3361a9fde13fb2aaf942
+  snowplow-react-native-tracker: 3f0b508aacf6ec7a4aceb2ce269387129641e13a
   SnowplowTracker: 6b19c331d5b765bda8b97b1c70ab52491524da60
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 6f5ab94cd8b1ecd04b6e973d0bc583ede2a598cc

--- a/ios/ReactNativeTracker.mm
+++ b/ios/ReactNativeTracker.mm
@@ -2,10 +2,6 @@
 
 @interface RCT_EXTERN_MODULE(ReactNativeTracker, NSObject)
 
-RCT_EXTERN_METHOD(multiply:(float)a withB:(float)b
-                 withResolver:(RCTPromiseResolveBlock)resolve
-                 withRejecter:(RCTPromiseRejectBlock)reject)
-
 RCT_EXTERN_METHOD(createTracker:
                   (NSDictionary *)argmap
                   resolver:(RCTPromiseResolveBlock)resolve

--- a/ios/Util/TrackerVersion.swift
+++ b/ios/Util/TrackerVersion.swift
@@ -1,3 +1,3 @@
 import Foundation
 
-let kRNTrackerVersion = "rn-2.1.1"
+let kRNTrackerVersion = "rn-2.1.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowplow/react-native-tracker",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A library for tracking Snowplow events in React Native",
   "homepage": "https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/react-native-tracker/",
   "main": "lib/commonjs/index",

--- a/src/jsCore.ts
+++ b/src/jsCore.ts
@@ -37,7 +37,7 @@ import { schemas } from './constants';
 import { v4 as uuid } from 'uuid';
 
 // Tracker version added to the events
-const trackerVersion = 'rn-2.1.1';
+const trackerVersion = 'rn-2.1.2';
 
 interface Tracker extends TrackerCore {
   setDomainUserId: (duid: string | undefined) => void;


### PR DESCRIPTION
This patch release adds support for React Native new architecture by fixing an issue on iOS that caused crashes when the tracker was used under the new architecture.

**Bug fixes:**

- Fix crash on iOS on React Native new architecture (#212)